### PR TITLE
fix(backend): improve GitHub URL parsing and error handling

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 import uuid
 import json
+import requests
 from flask import Flask, jsonify, request, abort
 from flask_cors import CORS
 from datetime import datetime, UTC
@@ -28,9 +29,9 @@ def classify_aurora():
 
     if not projectDescription:
         return jsonify({'error': 'Project description is required'}), 400
-    
-   
-    
+
+
+
     # 1. Aurora API Model (text-based)
     print("\n===== RUNNING AURORA API MODEL =====")
     try:
@@ -39,15 +40,15 @@ def classify_aurora():
             project_name=projectName,
             project_url=projectUrl
         )
-       
+
         print("Aurora API model completed successfully")
     except Exception as e:
         print(f"Aurora API model failed: {str(e)}")
-        aurora_result = {
+        return jsonify({
             "error": str(e),
             "message": "Aurora API classification failed"
-        }
-    
+        }), 500
+
     # Transform predictions to array format
     sdg_preds = aurora_result.get("sdg_predictions", {})
     if isinstance(sdg_preds, dict):
@@ -57,9 +58,9 @@ def classify_aurora():
         ]
     else:
         preds = sdg_preds  # Already in correct format
-    
+
     filtered_predictions = [p for p in preds if p.get("prediction", 0) > 0.4]
-    
+
     return jsonify({
         "projectName": aurora_result.get("project_name"),
         "projectUrl": aurora_result.get("project_url"),
@@ -76,8 +77,8 @@ def classify_st_description():
 
     if not projectDescription:
         return jsonify({'error': 'Project description is required'}), 400
-    
-  
+
+
     # 3. Sentence Transformer Description Model (text-based)
     print("\n===== RUNNING SENTENCE TRANSFORMER DESCRIPTION MODEL =====")
     try:
@@ -86,7 +87,7 @@ def classify_st_description():
             project_name=projectName,
             project_url=projectUrl
         )
-       
+
         print("ST Description model completed successfully")
     except Exception as e:
         print(f"ST Description model failed: {str(e)}")
@@ -95,9 +96,9 @@ def classify_st_description():
             "message": "Sentence Transformer Description model classification failed"
         }
         return jsonify(st_desc_result), 500
-    
+
     # Convert st-description-model predictions to the expected format for logging
-    # (keeping backward compatibility with existing data/predictions.json structure)   
+    # (keeping backward compatibility with existing data/predictions.json structure)
     preds = [
         {"sdg": name, "prediction": score}
         for name, score in st_desc_result.get("sdg_predictions", {}).items()
@@ -119,22 +120,31 @@ def classify_st_url():
 
     if not projectDescription:
         return jsonify({'error': 'Project description is required'}), 400
-    
-   
+
+
 
      # 2. Sentence Transformer URL Model (GitHub URL-based)
     print("\n===== RUNNING SENTENCE TRANSFORMER URL MODEL =====")
     if projectUrl:
         try:
             st_url_result = classify_url(projectUrl)
-            
+
             print("ST URL model completed successfully")
+        except ValueError as ve:
+            print(f"ST URL model invalid URL: {str(ve)}")
+            return jsonify({'error': str(ve)}), 400
+        except requests.exceptions.HTTPError as he:
+            print(f"ST URL model HTTP Error: {str(he)}")
+            return jsonify({
+                "error": f"Failed to fetch repository data. Please ensure the repository is public and exists. ({str(he)})",
+                "message": "Sentence Transformer URL model classification failed"
+            }), 400
         except Exception as e:
             print(f"ST URL model failed: {str(e)}")
-            st_url_result = {
+            return jsonify({
                 "error": str(e),
                 "message": "Sentence Transformer URL model classification failed"
-            }
+            }), 500
     else:
         st_url_result = {
             "message": "No project URL provided, skipping URL-based classification"
@@ -150,7 +160,7 @@ def classify_st_url():
             "projectUrl": projectUrl,
             "predictions": filtered_predictions,
         }), 200
-    
+
 # @app.post("/api/upload-md")
 # def aurora_api():
 
@@ -161,7 +171,7 @@ def classify_st_url():
 #         return jsonify({"error": "Project name is required"}), 400
 #     if not project_url:
 #         return jsonify({"error": "Project URL is required"}), 400
-    
+
 
 #     if "file" not in request.files:
 #         return jsonify({"error":"No file part named 'file' in form-data."}), 400
@@ -172,20 +182,20 @@ def classify_st_url():
 #     if not allowed_ext(f.filename):
 #         return jsonify({"error" : "Only .md files are allowed."}), 400
 
-   
+
 #     filename = secure_filename(f.filename)
 
 #     text = f.read().decode("utf-8", errors="replace")
 
 #     result = aurora_main(text)
-    
+
 #     return jsonify({
 #         "project_name": project_name,
 #         "project_url": project_url,
 #         "filename": filename,
 #         "size_bytes": len(text.encode("utf-8")),
-#         "content_preview": text[:2000],  
-#         "predictions": result.get("predictions", "") 
+#         "content_preview": text[:2000],
+#         "predictions": result.get("predictions", "")
 #     }), 200
 
 if __name__ == '__main__':

--- a/backend/embedding_url.py
+++ b/backend/embedding_url.py
@@ -2,6 +2,7 @@ import os
 import re
 import base64
 import requests
+from urllib.parse import urlparse
 from typing import List, Dict, Tuple
 from transformers import pipeline
 from sentence_transformers import SentenceTransformer
@@ -13,16 +14,33 @@ GITHUB_API = "https://api.github.com"
 
 def parse_repo(url: str) -> Tuple[str, str]:
     """
-    Accepts URLs like https://github.com/owner/repo or owner/repo.
+    Accepts strictly URLs like https://github.com/owner/repo or owner/repo.
     Returns (owner, repo).
+    Raises ValueError if URL is invalid.
     """
     u = url.strip()
-    if u.startswith("http"):
-        parts = u.rstrip("/").split("/")
-        owner, repo = parts[-2], parts[-1]
+    if u.startswith("http://") or u.startswith("https://"):
+        parsed = urlparse(u)
+        if parsed.hostname not in ["github.com", "www.github.com"]:
+            raise ValueError(f"Invalid domain (expected github.com): {url}")
+            
+        path_parts = parsed.path.strip("/").split("/")
+        if len(path_parts) != 2:
+            raise ValueError(f"Invalid repository URL format (expected https://github.com/owner/repo): {url}")
+            
+        owner, repo = path_parts[0], path_parts[1]
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return owner, repo
     else:
-        owner, repo = u.split("/", 1)
-    return owner, repo
+        parts = u.strip("/").split("/")
+        if len(parts) != 2:
+            raise ValueError(f"Invalid repository format (expected owner/repo): {url}")
+            
+        owner, repo = parts[0], parts[1]
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return owner, repo
 
 def gh_get(path: str, params: dict = None, accept_preview: bool = False) -> dict:
     headers = {"User-Agent": "sdg-classifier"}


### PR DESCRIPTION
Previously, the `parse_repo` function handled GitHub URLs unsafely by blindly splitting the string on "/" and accessing `parts[-2]`. If a user submitted a malformed URL with fewer slashes, it threw an IndexError.

Also passing overly long URLs would silently parse incorrect segments as the repository name resulting in 404 Not Found API errors that were caught by an overly broad try-except block and reported as a 500 Internal Server Error.

Fixes:

- refactored `parse_repo` to use `urllib.parse` to enforce strict formatting rules:
  - If a full URL is provided, it **must** be on the domain `github.com` or `www.github.com`.
  - The path must contain exactly two elements (`owner/repo`), rejecting any nested URLs.
  - The parser actively strips `.git` extensions if present.
- updated the `/api/classify_st_url` endpoint to specifically catch ValueError (invalid formats) and `requests.exceptions.HTTPError` (GitHub 404s/rate limits) and return a 400 Bad Request.

## Tests

Sending a malformed URL now correctly halts execution and alerts the client with a specific error message.

**Example 1: Invalid domain):**
```json
{
  "error": "Invalid domain (expected github.com): https://gitlab.com/owner/repo"
}
```
HTTP Status: `400 Bad Request`

**Example 2 (Invalid path structure):**
```json
{
  "error": "Invalid repository URL format (expected https://github.com/owner/repo): https://github.com/microsoft/PlanetaryComputer/eruf"
}
```
HTTP Status: `400 Bad Request`

Normal functionality remains for valid URLs with no regressions:

```json
{
  "predictions": [
    {
      "prediction": 0.583,
      "sdg": "SDG 13: Climate Action"
    },
    {
      "prediction": 0.569,
      "sdg": "SDG 7: Affordable and Clean Energy"
    },
    {
      "prediction": 0.561,
      "sdg": "SDG 15: Life on Land"
    },
    {
      "prediction": 0.548,
      "sdg": "SDG 4: Quality Education"
    },
    {
      "prediction": 0.543,
      "sdg": "SDG 9: Industry, Innovation and Infrastructure"
    },
    {
      "prediction": 0.542,
      "sdg": "SDG 8: Decent Work and Economic Growth"
    },
    {
      "prediction": 0.522,
      "sdg": "SDG 2: Zero Hunger"
    },
    {
      "prediction": 0.517,
      "sdg": "SDG 3: Good Health and Well-being"
    },
    {
      "prediction": 0.517,
      "sdg": "SDG 11: Sustainable Cities and Communities"
    },
    {
      "prediction": 0.509,
      "sdg": "SDG 1: No Poverty"
    }
  ],
  "projectName": "Test",
  "projectUrl": " https://github.com/microsoft/PlanetaryComputer"
}
```

`HTTP Status: 200`

Please let me know if you would like any changes to the URL parsing. I feel the stricter it is the better.

Also there are a lot of trailing whitespaces that got into the commit because of my Neovim config auto-removing them, is that fine?