### PR TITLE
Harden SDG parsing in CardGrid and EditModal

### DIFF
--- a/frontend/components/cardGrid.tsx
+++ b/frontend/components/cardGrid.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SDGValue, SDGCardProps, CardGridProps } from "@/types/main";
+import { SDGValue, CardGridProps } from "@/types/main";
 
 /*
 CardGrid Component
@@ -7,10 +7,13 @@ CardGrid Component
 - Each card shows SDG number, name, confidence score, and a progress bar
 */
 
-const SDGCard = ({ sdgKey, confidence }: SDGCardProps) => {
-  const sdgMatch = sdgKey.match(/SDG (\d+): (.+)/);
-  const sdgNumber = sdgMatch ? sdgMatch[1] : "";
-  const sdgName = sdgMatch ? sdgMatch[2] : sdgKey;
+type SDGCardProps = {
+  sdgNumber: string;
+  sdgName: string;
+  confidence: number;
+};
+
+const SDGCard = ({ sdgNumber, sdgName, confidence }: SDGCardProps) => {
 
   const confidenceScore = Number(confidence);
   const confidencePercentage = Math.round(confidenceScore * 100);
@@ -93,36 +96,48 @@ const SDGCard = ({ sdgKey, confidence }: SDGCardProps) => {
 };
 
 const CardGrid = ({ sdgPredictions }: CardGridProps) => {
-  const predictionsArray: SDGValue[] = Array.isArray(sdgPredictions)
-    ? sdgPredictions
-    : (Object.values(sdgPredictions ?? {})
-        .filter((item): item is SDGValue => {
-          return item.sdg != null && item.prediction > 0;
-        })
-        .map((item) => ({
-          prediction: item.prediction,
-          sdg: item.sdg,
-        })) as SDGValue[]);
+  const predictionsArray: Array<SDGValue & { sourceKey: string }> =
+    Array.isArray(sdgPredictions)
+      ? sdgPredictions.map((item, index) => ({
+          ...item,
+          sourceKey: String(index),
+        }))
+      : (Object.entries(sdgPredictions ?? {})
+          .map(([sourceKey, item]) => {
+            if (typeof item === "number") {
+              return { prediction: item, sourceKey };
+            }
+            return { ...item, sourceKey };
+          })
+          .filter((item): item is SDGValue & { sourceKey: string } => {
+            return item.sdg != null && item.prediction > 0;
+          }) as Array<SDGValue & { sourceKey: string }>);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {predictionsArray
         .sort((a, b) => b.prediction - a.prediction)
         .map((item, index) => {
-          // Handle both string and object formats for sdg
-          const sdgKey =
+          const fallbackNumberFromKey = item.sourceKey.match(/\d+/)?.[0];
+          const sdgNumber =
             typeof item.sdg === "string"
-              ? item.sdg
-              : `SDG ${item.sdg?.code}: ${item.sdg?.name}`;
-          const sdgCode =
+              ? item.sdg.match(/\d+/)?.[0] ||
+                fallbackNumberFromKey ||
+                (index + 1).toString()
+              : item.sdg?.code || fallbackNumberFromKey || (index + 1).toString();
+          const sdgName =
             typeof item.sdg === "string"
-              ? item.sdg.match(/SDG (\d+)/)?.[1] || index.toString()
-              : item.sdg?.code || index.toString();
+              ? item.sdg.replace(/^SDG\s*\d+\s*:?\s*/i, "").trim() || item.sdg
+              : item.sdg?.name ||
+                item.sdg?.label ||
+                item.sourceKey.replace(/^SDG\s*\d+\s*:?\s*/i, "").trim() ||
+                `SDG ${sdgNumber}`;
 
           return (
             <SDGCard
-              key={sdgCode}
-              sdgKey={sdgKey}
+              key={`${sdgNumber}-${index}`}
+              sdgNumber={sdgNumber}
+              sdgName={sdgName}
               confidence={item.prediction}
             />
           );

--- a/frontend/components/editModal.tsx
+++ b/frontend/components/editModal.tsx
@@ -19,6 +19,26 @@ const EditModal: React.FC<EditModalProps> = ({
   setIsModalOpen,
   saveEditedResults,
 }) => {
+  const parseSdgFromString = (value: string) => {
+    const number = value.match(/\d+/)?.[0] ?? "";
+    const name = value.replace(/^SDG\s*\d+\s*:?\s*/i, "").trim() || value;
+    return { number, name };
+  };
+
+  const getSdgNumber = (sdgKey: string, value: SDGValue) => {
+    if (typeof value.sdg === "string") {
+      return parseSdgFromString(value.sdg).number || sdgKey;
+    }
+    return value?.sdg?.code ?? parseSdgFromString(sdgKey).number ?? sdgKey;
+  };
+
+  const getSdgName = (sdgKey: string, value: SDGValue) => {
+    if (typeof value.sdg === "string") {
+      return parseSdgFromString(value.sdg).name;
+    }
+    return value?.sdg?.name ?? value?.sdg?.label ?? sdgKey;
+  };
+
   const [showAddForm, setShowAddForm] = useState(false);
   const [newSDGNumber, setNewSDGNumber] = useState("");
   const [newSDGName, setNewSDGName] = useState("");
@@ -40,7 +60,7 @@ const EditModal: React.FC<EditModalProps> = ({
     if (newSDGNumber && newSDGName) {
       const sdgKey = Object.keys(editableResults).length;
       const exists = Object.values(editableResults).some(
-        (value) => String(value?.sdg?.code) === String(newSDGNumber),
+        (value) => String(getSdgNumber("", value)) === String(newSDGNumber),
       );
 
       if (exists) {
@@ -201,9 +221,8 @@ const EditModal: React.FC<EditModalProps> = ({
               )
               .map(([sdgKey, value]) => {
                 const confidence = value.prediction ?? 0;
-                const sdgNumber =
-                  value?.sdg?.code ?? sdgKey.match(/SDG (\d+):/)?.[1] ?? "";
-                const sdgName = value?.sdg?.name ?? sdgKey;
+                const sdgNumber = getSdgNumber(sdgKey, value);
+                const sdgName = getSdgName(sdgKey, value);
 
                 return (
                   <div


### PR DESCRIPTION
## Description

This PR makes a fix to remove brittle SDG string parsing in the frontend results views.

### Changes made

- Updated `cardGrid.tsx` to stop relying on strict `"SDG <n>: <name>"` parsing
- `SDGCard` now receives explicit `sdgNumber` and `sdgName` props.
- CardGrid normalization now preserves each prediction entry key and uses it as a fallback when SDG object fields are missing.
- Added resilient fallback order for number/name extraction
- Updated `frontend/components/editModal.tsx` with shared-safe parsing helpers to avoid regex-only assumptions.
- Updated duplicate SDG detection in the modal to use normalized SDG number extraction, so mixed data shapes are handled correctly.

### Justification
- API responses can include SDG metadata as either structured objects or free-form strings.
- The previous implementation depended on one strict string format and could render empty/wrong values when the format differed.

## Test results

- `npm run lint -- components/cardGrid.tsx components/editModal.tsx` -> Pass
- `npm run build` (frontend) -> Pass

- Parser scenario checks (Node script) for both CardGrid and EditModal logic -> 5/5 Pass
  - Object SDG with `code` + `name`
  - Object SDG with `code` + `label`
  - Canonical string (`SDG 13: Climate Action`)
  - Variant string (`Goal 12 Responsible Consumption`)
  - Missing `code` in object with fallback from key
