### PR TITLE
feat: Add batch repository analysis for multiple GitHub repos

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 import os
 # import uuid
 # import json
+import time
 import requests
 from flask import Flask, jsonify, request, abort
 from flask_cors import CORS
@@ -198,6 +199,85 @@ def osdg_external_api():
         "projectUrl": projectUrl,
         "predictions": osdg_result
     }), 200
+@app.route('/api/classify_batch', methods=['POST'])
+def classify_batch():
+    data = request.get_json()
+    repositories = data.get('repositories', [])
+
+    if not repositories:
+        return jsonify({"error": "No repositories provided"}), 400
+
+    if len(repositories) > 20:
+        return jsonify({"error": "Maximum 20 repositories allowed per batch"}), 400
+
+    results = []
+
+    for repo in repositories:
+        project_name = repo.get('projectName', '')
+        project_url = repo.get('projectUrl', '')
+        project_description = repo.get('projectDescription', '')
+
+        if not project_url:
+            results.append({
+                "projectName": project_name,
+                "projectUrl": project_url,
+                "status": "error",
+                "error": "Missing project URL"
+            })
+            continue
+
+        if not project_description:
+            results.append({
+                "projectName": project_name,
+                "projectUrl": project_url,
+                "status": "error",
+                "error": "Missing project description"
+            })
+            continue
+
+        try:
+            aurora_result = aurora_classify(
+                text=project_description,
+                project_name=project_name,
+                project_url=project_url
+            )
+
+            sdg_preds = aurora_result.get("sdg_predictions", {})
+
+            if isinstance(sdg_preds, dict):
+                preds = [
+                    {"sdg": name, "prediction": score}
+                    for name, score in sdg_preds.items()
+                ]
+            else:
+                preds = sdg_preds
+
+            filtered = [p for p in preds if p.get("prediction", 0) > 0.4]
+            top = max(filtered, key=lambda x: x['prediction']) if filtered else None
+
+            results.append({
+                "projectName": project_name,
+                "projectUrl": project_url,
+                "status": "success",
+                "topSdg": top['sdg'] if top else "N/A",
+                "confidence": round(top['prediction'], 3) if top else 0,
+                "allPredictions": filtered
+            })
+
+        except Exception as e:
+            print(f"Batch classification failed for {project_url}: {str(e)}")
+            results.append({
+                "projectName": project_name,
+                "projectUrl": project_url,
+                "status": "error",
+                "error": str(e)
+            })
+
+        time.sleep(1)  # Rate limit protection
+
+    return jsonify({"results": results, "total": len(results)}), 200
+
+
 # @app.post("/api/upload-md")
 # def aurora_api():
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,36 +4,51 @@ import { useState } from "react";
 import Results from "@/components/results";
 import Error from "@/components/error";
 import MainScreen from "@/components/mainScreen";
+import BatchScreen from "@/components/batchScreen";
 import { ResultsData } from "@/types/main";
 
-/**
- * Main Application Component - UN SDG Advocate
- *
- * Flow:
- * 1. User enters Project Name, GitHub repository URL and project SDG relevance description
- * 2. The data is then sent to Flask backend for analysis
- * 4. Results show SDG predictions with confidence levels
- * 5. User can edit predictions via modal interface
- * 6. Edited results are saved and stored in state
- */
 export default function Home() {
   const [results, setResults] = useState<ResultsData | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  console.log("Current Results State:", results);
+  const [mode, setMode] = useState<"single" | "batch">("single");
 
   return (
     <div className="min-h-screen bg-gradient-to-br">
       {results ? (
-        <Results
-          results={results}
-          setResults={setResults}
-          setError={setError}
-        />
+        <Results results={results} setResults={setResults} setError={setError} />
       ) : error ? (
         <Error error={error} setError={setError} setResults={setResults} />
       ) : (
-        <MainScreen setResults={setResults} />
+        <>
+          <div className="flex justify-center gap-4 pt-6">
+            <button
+              onClick={() => setMode("single")}
+              className={`px-6 py-2 rounded-full font-semibold transition-all ${
+                mode === "single"
+                  ? "bg-purple-700 text-white"
+                  : "bg-white text-purple-700 border border-purple-700"
+              }`}
+            >
+              Single Repository
+            </button>
+            <button
+              onClick={() => setMode("batch")}
+              className={`px-6 py-2 rounded-full font-semibold transition-all ${
+                mode === "batch"
+                  ? "bg-purple-700 text-white"
+                  : "bg-white text-purple-700 border border-purple-700"
+              }`}
+            >
+              Batch Analysis
+            </button>
+          </div>
+
+          {mode === "single" ? (
+            <MainScreen setResults={setResults} />
+          ) : (
+            <BatchScreen />
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/components/batchScreen.tsx
+++ b/frontend/components/batchScreen.tsx
@@ -1,0 +1,221 @@
+"use client";
+import { useState } from "react";
+import { AiOutlineLoading3Quarters } from "react-icons/ai";
+import { classifyBatch } from "@/services/api";
+import { BatchResult } from "@/types/main";
+
+const BatchScreen = () => {
+  const [urlsText, setUrlsText] = useState("");
+  const [description, setDescription] = useState("");
+  const [results, setResults] = useState<BatchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleAnalyze = async () => {
+    const lines = urlsText
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.includes("github.com"));
+
+    if (lines.length === 0) {
+      setError("Please enter at least one valid GitHub URL.");
+      return;
+    }
+    if (lines.length > 20) {
+      setError("Maximum 20 repositories allowed.");
+      return;
+    }
+    if (!description.trim()) {
+      setError("Please enter a common description.");
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+    setResults([]);
+
+    const repositories = lines.map((url) => ({
+      projectName: url.split("/").pop() || url,
+      projectUrl: url,
+      projectDescription: description,
+    }));
+
+    try {
+      const data = await classifyBatch(repositories);
+      setResults(data.results);
+    } catch {
+      setError("Batch analysis failed. Make sure backend is running.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDownloadCSV = () => {
+    const header = "Project Name,URL,Top SDG,Confidence,Status\n";
+    const rows = results
+      .map(
+        (r) =>
+          `"${r.projectName}","${r.projectUrl}","${r.topSdg || "N/A"}",${
+            r.confidence ? (r.confidence * 100).toFixed(1) + "%" : "N/A"
+          },${r.status}`
+      )
+      .join("\n");
+    const blob = new Blob([header + rows], { type: "text/csv" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "batch_sdg_analysis.csv";
+    a.click();
+  };
+
+  const handleDownloadJSON = () => {
+    const blob = new Blob([JSON.stringify({ results }, null, 2)], {
+      type: "application/json",
+    });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "batch_sdg_analysis.json";
+    a.click();
+  };
+
+  return (
+    <div className="text-center px-8 py-16 bg-purple-400">
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-bold text-white mb-2">
+            Batch Repository Analysis
+          </h2>
+          <p className="text-white text-sm">
+            Analyze up to 20 GitHub repositories at once
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2 text-left">
+              GitHub URLs (one per line)
+              <span className="text-red-500 ml-1">*</span>
+            </label>
+            <textarea
+              value={urlsText}
+              onChange={(e) => setUrlsText(e.target.value)}
+              placeholder={"https://github.com/oppia/oppia\nhttps://github.com/facebook/react"}
+              rows={6}
+              disabled={loading}
+              className="w-full bg-white px-6 py-4 rounded-2xl border border-gray-200 text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all font-mono text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2 text-left">
+              Common SDG Relevance Description
+              <span className="text-red-500 ml-1">*</span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Describe the SDG relevance common to these projects (100-120 words recommended)"
+              rows={5}
+              disabled={loading}
+              className="w-full bg-white px-6 py-4 rounded-2xl border border-gray-200 text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+            />
+          </div>
+
+          {error && (
+            <div className="p-4 rounded-2xl bg-red-50 text-red-700 border border-red-200 text-left">
+              {error}
+            </div>
+          )}
+
+          {loading && (
+            <p className="text-white text-sm">
+              Processing repositories sequentially to respect API rate limits...
+            </p>
+          )}
+
+          <button
+            onClick={handleAnalyze}
+            disabled={loading}
+            className="w-full px-8 py-4 bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-2xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+          >
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <AiOutlineLoading3Quarters className="animate-spin h-5 w-5" />
+                Analyzing...
+              </span>
+            ) : (
+              "Analyze All Repositories"
+            )}
+          </button>
+        </div>
+
+        {results.length > 0 && (
+          <div className="mt-10">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-white font-semibold text-lg">
+                Results ({results.length} repositories)
+              </h3>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleDownloadCSV}
+                  className="text-sm bg-white text-purple-700 px-3 py-1 rounded-lg hover:bg-purple-50"
+                >
+                  Download CSV
+                </button>
+                <button
+                  onClick={handleDownloadJSON}
+                  className="text-sm bg-white text-purple-700 px-3 py-1 rounded-lg hover:bg-purple-50"
+                >
+                  Download JSON
+                </button>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto rounded-2xl border bg-white">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-purple-50">
+                  <tr>
+                    <th className="p-4 font-semibold text-gray-700">Repository</th>
+                    <th className="p-4 font-semibold text-gray-700">Top SDG</th>
+                    <th className="p-4 font-semibold text-gray-700">Confidence</th>
+                    <th className="p-4 font-semibold text-gray-700">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((r, i) => (
+                    <tr key={i} className="border-t hover:bg-gray-50">
+                      <td className="p-4">
+                        <a
+                          href={r.projectUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-purple-600 hover:underline"
+                        >
+                          {r.projectName}
+                        </a>
+                      </td>
+                      <td className="p-4 text-gray-700">{r.topSdg || "—"}</td>
+                      <td className="p-4 text-gray-700">
+                        {r.confidence
+                          ? `${(r.confidence * 100).toFixed(1)}%`
+                          : "—"}
+                      </td>
+                      <td className="p-4">
+                        {r.status === "success" ? (
+                          <span className="text-green-600 font-medium">Success</span>
+                        ) : (
+                          <span className="text-red-500">Failed: {r.error}</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BatchScreen;

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,9 +1,6 @@
 import axios from "axios";
-import {
-  ResultsData,
-  SDGClassificationRequest,
-  SDGClassificationResponse,
-} from "@/types/main";
+import { BatchResult, ResultsData, SDGClassificationRequest, SDGClassificationResponse } from "@/types/main";
+
 
 const API_BASE_URL = "http://127.0.0.1:5000/";
 
@@ -62,4 +59,13 @@ export const classifyByModel = async (
     default:
       return sdgApi.classifyAurora(data);
   }
+};
+
+export const classifyBatch = async (repositories: {
+  projectName: string;
+  projectUrl: string;
+  projectDescription: string;
+}[]): Promise<{ results: BatchResult[]; total: number }> => {
+  const response = await apiClient.post('/api/classify_batch', { repositories });
+  return response.data;
 };

--- a/frontend/types/main.d.ts
+++ b/frontend/types/main.d.ts
@@ -70,3 +70,12 @@ export type EditModalProps = {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   saveEditedResults: () => void;
 };
+export type BatchResult = {
+  projectName: string;
+  projectUrl: string;
+  status: "success" | "error";
+  topSdg?: string;
+  confidence?: number;
+  allPredictions?: { sdg: string; prediction: number }[];
+  error?: string;
+};


### PR DESCRIPTION
Closes #9
## Summary
Added batch repository analysis feature that allows users to classify 
multiple GitHub repositories against UN SDGs in a single request.

## Changes

### Backend
- Added `/api/classify_batch` endpoint in `app.py`
- Reuses existing Aurora model for each repository
- Processes repositories sequentially with 1s delay to respect API rate limits(we can adjust the delay)
- Max 20 repositories per request (we can add more according to needs)
- Returns topSdg, confidence score, and allPredictions per repo

### Frontend
- Added `BatchScreen` component (`components/batchScreen.tsx`)
- Added `BatchResult` type in `types/main.d.ts`
- Added `classifyBatch` function in `services/api.ts`
- Added mode toggle (Single / Batch) in `app/page.tsx`
- Results displayed in summary table
- Bulk download as CSV or JSON

## Testing
- Valid batch input → returns results table ✅
- Invalid URL → shows validation error ✅
- Empty fields → shows error ✅
- Backend down → shows clear error message ✅
- Download CSV → correct data ✅
- Download JSON → correct structure ✅