### PR TITLE
fix: refactor frontend state flow to remove prop drilling

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import Results from "@/components/results";
 import Error from "@/components/error";
 import MainScreen from "@/components/mainScreen";
-import { ResultsData } from "@/types/main";
+import { AppStateProvider, useAppState } from "@/lib/appStateContext";
 
 /**
  * Main Application Component - UN SDG Advocate
@@ -17,24 +16,21 @@ import { ResultsData } from "@/types/main";
  * 6. Edited results are saved and stored in state
  */
 export default function Home() {
-  const [results, setResults] = useState<ResultsData | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  return (
+    <AppStateProvider>
+      <HomeContent />
+    </AppStateProvider>
+  );
+}
+
+const HomeContent = () => {
+  const { results, error } = useAppState();
 
   console.log("Current Results State:", results);
 
   return (
     <div className="min-h-screen bg-gradient-to-br">
-      {results ? (
-        <Results
-          results={results}
-          setResults={setResults}
-          setError={setError}
-        />
-      ) : error ? (
-        <Error error={error} setError={setError} setResults={setResults} />
-      ) : (
-        <MainScreen setResults={setResults} />
-      )}
+      {results ? <Results /> : error ? <Error /> : <MainScreen />}
     </div>
   );
-}
+};

--- a/frontend/components/error.tsx
+++ b/frontend/components/error.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { RiErrorWarningFill } from "react-icons/ri";
-import { ErrorProps } from "@/types/main";
+import { useAppState } from "@/lib/appStateContext";
 
 /*
 Error Component
@@ -9,7 +9,9 @@ Error Component
 
 */
 
-const Error: React.FC<ErrorProps> = ({ error, setError, setResults }) => {
+const Error = () => {
+  const { error, setError, setResults } = useAppState();
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br">
       <div className="text-center space-y-6 max-w-md">

--- a/frontend/components/mainScreen.tsx
+++ b/frontend/components/mainScreen.tsx
@@ -6,6 +6,7 @@ import { ImCross } from "react-icons/im";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import { ResultsData } from "@/types/main";
 import { sdgApi } from "@/services/api";
+import { useAppState } from "@/lib/appStateContext";
 
 /*
 MainScreen Component
@@ -14,9 +15,8 @@ MainScreen Component
 
 */
 
-const MainScreen: React.FC<{
-  setResults: React.Dispatch<React.SetStateAction<ResultsData | null>>;
-}> = ({ setResults }) => {
+const MainScreen = () => {
+  const { setResults } = useAppState();
   const [isUploading, setIsUploading] = useState(false);
   const [uploadMsg, setUploadMsg] = useState<string | null>(null);
 

--- a/frontend/components/results.tsx
+++ b/frontend/components/results.tsx
@@ -7,19 +7,15 @@ import EditModal from "./editModal";
 import { SDGValue, ResultsData } from "@/types/main";
 import { IoIosInformationCircleOutline } from "react-icons/io";
 import { classifyByModel } from "@/services/api";
+import { useAppState } from "@/lib/appStateContext";
 /*
 Results Component
 - Displays the results of the SDG analysis
 - Shows SDG cards, allows editing via modal, and downloading results
 */
 
-type ResultsProps = {
-  results: ResultsData | null;
-  setResults: (value: ResultsData | null) => void;
-  setError: (value: string | null) => void;
-};
-
-const Results = ({ results, setResults, setError }: ResultsProps) => {
+const Results = () => {
+  const { results, setResults, setError } = useAppState();
   const [editableResults, setEditableResults] = useState<
     Record<string, SDGValue>
   >({});

--- a/frontend/lib/appStateContext.tsx
+++ b/frontend/lib/appStateContext.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useState,
+} from "react";
+import { ResultsData } from "@/types/main";
+
+type AppStateContextValue = {
+  results: ResultsData | null;
+  setResults: Dispatch<SetStateAction<ResultsData | null>>;
+  error: string | null;
+  setError: Dispatch<SetStateAction<string | null>>;
+};
+
+const AppStateContext = createContext<AppStateContextValue | undefined>(
+  undefined,
+);
+
+export const AppStateProvider = ({ children }: { children: ReactNode }) => {
+  const [results, setResults] = useState<ResultsData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <AppStateContext.Provider value={{ results, setResults, error, setError }}>
+      {children}
+    </AppStateContext.Provider>
+  );
+};
+
+export const useAppState = () => {
+  const context = useContext(AppStateContext);
+  if (!context) {
+    throw new Error("useAppState must be used within AppStateProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Description

Refactor frontend state flow to remove prop drilling

This change centralizes app-level frontend state for analysis results and error handling using a small React context provider.

## Explanation

Prop drilling happens when state and callbacks are passed through multiple component layers only so deeper children can use them.

In this frontend flow, results and error setters were being passed from the top page into children. This creates tighter coupling, adds repetitive plumbing, and makes future changes riskier because every state shape change requires edits across multiple files and props.

Using a focused context keeps behavior the same while reducing wiring overhead, improving maintainability, and making consumers easier to reuse.

## Tests
- Ran lint on touched frontend files: pass.
- Ran frontend production build with type checking: pass.

## AI disclosure
This work was prepared with assistance from GPT-5.3 Codex using OpenCode. I reviewed the generated code and take full responsibility for all code and changes.