### PR TITLE
fix(backend): harden external API error handling for Aurora and OSDG

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 myvenv/
+venv/
 .env
 __pycache__/
 *.pyc

--- a/backend/app.py
+++ b/backend/app.py
@@ -50,6 +50,14 @@ def classify_aurora():
             "message": "Aurora API classification failed"
         }), 500
 
+    # Check if aurora_api.py caught an error internally and returned it in the dict
+    if "error" in aurora_result:
+        print(f"Aurora API returned error: {aurora_result['error']}")
+        return jsonify({
+            "error": aurora_result["error"],
+            "message": aurora_result.get("message", "Aurora API classification failed")
+        }), 502
+
     # Transform predictions to array format
     sdg_preds = aurora_result.get("sdg_predictions", {})
     if isinstance(sdg_preds, dict):
@@ -188,10 +196,11 @@ def osdg_external_api():
         osdg_result = osdg_response.json()
     except requests.exceptions.RequestException as e:
         print(f"OSDG API request failed: {str(e)}")
+        status_code = e.response.status_code if e.response is not None else 500
         return jsonify({
             "error": f"Failed to connect to OSDG API: {str(e)}",
             "message": "OSDG API classification failed"
-        }), 500
+        }), status_code
 
     return jsonify({
         "projectName": projectName,

--- a/backend/aurora_api.py
+++ b/backend/aurora_api.py
@@ -6,12 +6,12 @@ from sdg_constants import SDG_LABELS_DICT as SDG_LABELS
 def main(text: str, project_name: str = None, project_url: str = None):
     """
     Classify text using Aurora SDG API and format output to match embedding models.
-    
+
     Args:
         text: Project description text to classify
         project_name: Optional project name for metadata
         project_url: Optional project URL for metadata
-    
+
     Returns:
         Dictionary with predictions in standardized format
     """
@@ -20,26 +20,26 @@ def main(text: str, project_name: str = None, project_url: str = None):
         payload = json.dumps({"text": text})
         headers = {'Content-Type': 'application/json'}
         response = requests.request("POST", url, headers=headers, data=payload)
-        # response.raise_for_status()
-        
+        response.raise_for_status()
+
         raw_result = response.json()
-        
+
         # Transform Aurora API response to match embedding model format
         # Aurora API can return different structures, handle both cases
-        
+
         sdg_predictions = {}
-        
+
         # Check if predictions exist and iterate
         if "predictions" in raw_result and isinstance(raw_result["predictions"], list):
             for idx, pred in enumerate(raw_result["predictions"]):
-                
+
                 # Handle case where pred might be a dict with nested structure
                 if isinstance(pred, dict):
                     # Extract SDG code and score
                     sdg_code = None
                     sdg_name = None
                     score = None
-                    
+
                     # Check if sdg is a dict with code field (Aurora API format)
                     if "sdg" in pred and isinstance(pred["sdg"], dict):
                         sdg_value = pred["sdg"]
@@ -47,13 +47,13 @@ def main(text: str, project_name: str = None, project_url: str = None):
                         sdg_code = sdg_value.get("code")
                         # Try to get label from the API response
                         sdg_label = sdg_value.get("label") or sdg_value.get("name")
-                        
+
                         if sdg_code:
                             # Get the full SDG name from our mapping
                             sdg_full_name = SDG_LABELS.get(str(sdg_code), sdg_label or "")
                             # Format as "SDG {number}: {name}"
                             sdg_name = f"SDG {sdg_code}: {sdg_full_name}"
-                    
+
                     # Fallback to old logic if code extraction fails
                     if not sdg_name:
                         if "sdg" in pred:
@@ -65,10 +65,10 @@ def main(text: str, project_name: str = None, project_url: str = None):
                         # Try alternative field names
                         if not sdg_name:
                             sdg_name = pred.get("label") or pred.get("name") or pred.get("sdg_label")
-                    
+
                     # Get score/prediction value
                     score = pred.get("prediction") or pred.get("score") or pred.get("confidence") or 0
-                    
+
                     if sdg_name and isinstance(sdg_name, str):
                         # Format score to 3 decimal places
                         if score > 0.5:
@@ -77,7 +77,7 @@ def main(text: str, project_name: str = None, project_url: str = None):
                         print(f"DEBUG - Warning: Could not extract SDG name from prediction {idx}")
                 else:
                     print(f"DEBUG - Warning: Prediction {idx} is not a dict: {type(pred)}")
-        
+
         # Format output to match embedding_url.py structure
         formatted_result = {
             "project_name": project_name or "Unknown",
@@ -85,13 +85,13 @@ def main(text: str, project_name: str = None, project_url: str = None):
             "sdg_predictions": sdg_predictions,
             "method": "aurora-api",
         }
-        
-      
-        
+
+
+
         return formatted_result
-        
+
     except requests.exceptions.RequestException as e:
-       
+
         return {
             "project_name": project_name or "Unknown",
             "project_url": project_url or "",


### PR DESCRIPTION
## Description

This PR hardens how the backend handles failures from external ML APIs (Aurora SDG and OSDG).

### Problem

1. **`aurora_api.py`**: `response.raise_for_status()` was commented out. If the Aurora API returned a non-JSON response (e.g. an HTML error page during a 502 or 429), `response.json()` would throw an unhandled `JSONDecodeError` and crash the server.

2. **`app.py` (`/api/classify_aurora`)**: When `aurora_api.py` caught an error internally, it returned a dict containing an `"error"` key instead of raising an exception. The route handler never checked for this key, so it silently returned `200 OK` with zero predictions  making it look like the classification succeeded.

3. **`app.py` (`/api/osdg_api`)**: All external API failures were uniformly returned as `500 Internal Server Error`, even when the upstream API returned a specific status like `429 Too Many Requests`.

### Changes made

- Enabled `response.raise_for_status()` in `aurora_api.py` to fail fast on non-2xx responses before attempting JSON parsing.
- Added an `"error"` key check in the `/api/classify_aurora` route. If `aurora_api.py` returns an error dict, the route now returns `502 Bad Gateway` with the error details instead of a false `200`.
- Updated the `/api/osdg_api` error handler to forward the upstream API's actual HTTP status code instead of always returning `500`.
- Added `venv/` to `backend/.gitignore`

## Tests
I used postman for testing 
- `POST /api/classify_aurora` with valid input : `200` with predictions 
- `POST /api/classify_aurora` with Aurora API returning non-2xx : `502` with clean JSON error 
- `POST /api/classify_aurora` with empty description : `400` 
- No regressions to `/api/classify_st_url` or `/api/classify_st_description` routes 
