### PR TITLE
fix(frontend): display detailed backend API errors in global UI

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       ) : error ? (
         <Error error={error} setError={setError} setResults={setResults} />
       ) : (
-        <MainScreen setResults={setResults} />
+        <MainScreen setResults={setResults} setError={setError} />
       )}
     </div>
   );

--- a/frontend/components/mainScreen.tsx
+++ b/frontend/components/mainScreen.tsx
@@ -16,7 +16,8 @@ MainScreen Component
 
 const MainScreen: React.FC<{
   setResults: React.Dispatch<React.SetStateAction<ResultsData | null>>;
-}> = ({ setResults }) => {
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+}> = ({ setResults, setError }) => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadMsg, setUploadMsg] = useState<string | null>(null);
 
@@ -89,9 +90,10 @@ const MainScreen: React.FC<{
 
       // console.log("API Response:", response.data);
       setResults(response as ResultsData);
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error:", error);
-      setUploadMsg("Text Analyzing Failed. Please try again.");
+      const errorMessage = error.response?.data?.error || error.message || "Text Analyzing Failed. Please try again.";
+      setError(errorMessage);
     } finally {
       setIsUploading(false);
     }


### PR DESCRIPTION
### What this PR does
Previously, when the Flask backend threw an API error (such as a timeout or an invalid URL), the `MainScreen` component would catch it but only display a hardcoded local toast message (`"Text Analyzing Failed. Please try again."`). The actual backend error was only visible in the browser console.

This PR passes the global `setError` prop from `page.tsx` down to `MainScreen.tsx`. Now, when an Axios request fails, it extracts the exact `error.response.data.error` and triggers the beautiful global `<Error />` UI component. 

### Testing Instructions
1. Run the Next.js frontend (`npm run dev`).
2. Keep the Flask backend offline.
3. Submit the form.
4. Observe the screen correctly transition to the full-page Error UI with the specific network failure message.

### Before :

<img width="1284" height="297" alt="image" src="https://github.com/user-attachments/assets/7dd21a22-3bd4-4be3-8fa9-8247bd58d8c9" />

### After :

<img width="1132" height="643" alt="image" src="https://github.com/user-attachments/assets/cc7b56cd-7b29-4d9c-93ce-4c2f98a0808c" />



