### PR TITLE
Move hardcoded API endpoints and tokens to environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+OSDG_API_URL=http://20.73.166.85/label_text
+AURORA_API_URL=https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi
+OSDG_TOKEN=
+GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cd backend
 python3 -m venv myvenv
 source ./myvenv/bin/activate
 pip install -r requirements.txt
+cp .env.example .env
+# Update values if needed before starting backend
 python3 app.py
 ```
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,10 @@ from embedding_description import main as classify_description
 from embedding_url import main as classify_url
 from aurora_api import main as aurora_classify
 
+OSDG_API_URL = os.environ.get(
+    "OSDG_API_URL",
+    "http://20.73.166.85/label_text"
+)
 
 app = Flask(__name__)
 CORS(app)
@@ -175,7 +179,7 @@ def osdg_external_api():
     # Call the external OSDG API
     try:
         osdg_response = requests.post(
-            "http://20.73.166.85/label_text",
+            OSDG_API_URL,
             json={
                 "text": projectDescription
             },

--- a/backend/aurora_api.py
+++ b/backend/aurora_api.py
@@ -1,4 +1,5 @@
 import requests
+import os
 import json
 from sdg_constants import SDG_LABELS_DICT as SDG_LABELS
 
@@ -16,7 +17,10 @@ def main(text: str, project_name: str = None, project_url: str = None):
         Dictionary with predictions in standardized format
     """
     try:
-        url = "https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi"
+        url = os.environ.get(
+            "AURORA_API_URL",
+            "https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi"
+        )
         payload = json.dumps({"text": text})
         headers = {'Content-Type': 'application/json'}
         response = requests.request("POST", url, headers=headers, data=payload)


### PR DESCRIPTION
## Summary

Fixes #21.

Moves hardcoded backend API endpoints to environment-based configuration and adds a sample environment file for local setup.

## Changes

* Added `OSDG_API_URL` config in `backend/app.py`
* Added `AURORA_API_URL` config in `backend/aurora_api.py`
* Added `.env.example`
* Updated README setup instructions

## Why

This improves portability across local, staging, and production environments without requiring code changes when endpoints are updated.
