### PR TITLE
fix incorrect cd command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An AI-powered tool that analyzes GitHub repositories and determines their alignm
 
 ```bash
 git clone <repository-url>
-cd UNSDG-advocate
+cd UNSDG-classifier-tool
 ```
 
 ### 2. Bash script approach


### PR DESCRIPTION
Fixed incorrect directory name in the "Clone and Setup" section.
Replaced cd UNSDG-advocate with cd UNSDG-classifier-tool.