### PR TITLE
Improve onboarding docs with focus-group entry points

### DIFF
--- a/FOCUS GROUPS/communitymanagers-group.md
+++ b/FOCUS GROUPS/communitymanagers-group.md
@@ -1,0 +1,25 @@
+# UNSDG Classifier Community Managers Focus Group
+
+## About
+This group supports contributor onboarding, issue triage, and communication across the project community.
+
+## What this group works on
+- New contributor onboarding support
+- Issue hygiene, tagging, and follow-ups
+- Community updates and contribution guidance
+
+## Meeting time
+- Bi-weekly project call: see calendar in the main README
+
+## Group leads
+- Project maintainers listed in the repository README
+
+## How to join
+1. Introduce yourself in the project communication channels.
+2. Pick a triage or documentation support issue.
+3. Share updates and help unblock new contributors.
+
+## Suggested first tasks
+- Improve issue templates or triage labels.
+- Help categorize open issues by type/priority.
+- Draft a newcomer checklist for common contribution paths.

--- a/FOCUS GROUPS/designers-group.md
+++ b/FOCUS GROUPS/designers-group.md
@@ -1,0 +1,25 @@
+# UNSDG Classifier Designers Focus Group
+
+## About
+This group supports contributors interested in UI/UX improvements, accessibility, and user journey clarity.
+
+## What this group works on
+- UX feedback and wireframe proposals
+- Visual consistency and interaction polish
+- Accessibility improvements for core workflows
+
+## Meeting time
+- Bi-weekly project call: see calendar in the main README
+
+## Group leads
+- Project maintainers listed in the repository README
+
+## How to join
+1. Identify a design-oriented issue or propose one.
+2. Share mocks or annotated screenshots in the issue.
+3. Collaborate with developers to implement validated designs.
+
+## Suggested first tasks
+- Improve one confusing interaction in the analysis flow.
+- Propose better empty/error/loading states.
+- Review component accessibility and suggest fixes.

--- a/FOCUS GROUPS/developer-group.md
+++ b/FOCUS GROUPS/developer-group.md
@@ -1,0 +1,25 @@
+# UNSDG Classifier Developers Focus Group
+
+## About
+This group supports contributors working on application features, backend APIs, frontend improvements, and engineering quality.
+
+## What this group works on
+- Frontend and backend bug fixes
+- Feature implementation from open issues
+- Test coverage and code health
+
+## Meeting time
+- Bi-weekly project call: see calendar in the main README
+
+## Group leads
+- Project maintainers listed in the repository README
+
+## How to join
+1. Comment on a development issue you want to pick.
+2. Share your implementation plan in the issue thread.
+3. Open a PR with tests and clear notes.
+
+## Suggested first tasks
+- Pick a `good first issue` labeled item.
+- Fix one small bug and include a reproducible test plan.
+- Improve one API or UI validation flow.

--- a/FOCUS GROUPS/researchers-group.md
+++ b/FOCUS GROUPS/researchers-group.md
@@ -1,0 +1,25 @@
+# UNSDG Classifier Researchers Focus Group
+
+## About
+This group supports contributors focused on SDG methodology quality, evaluation, and evidence-backed improvements.
+
+## What this group works on
+- SDG mapping validation and review
+- Confidence score interpretation quality
+- Research-backed recommendations for classifier improvements
+
+## Meeting time
+- Bi-weekly project call: see calendar in the main README
+
+## Group leads
+- Project maintainers listed in the repository README
+
+## How to join
+1. Review current SDG classification outputs and open issues.
+2. Propose a scoped research task in an issue.
+3. Document findings with clear, reproducible reasoning.
+
+## Suggested first tasks
+- Validate one sample set of predictions and report observations.
+- Suggest metrics for evaluating classification quality.
+- Improve SDG-related documentation for contributor clarity.

--- a/FOCUS GROUPS/technicalwriters-group.md
+++ b/FOCUS GROUPS/technicalwriters-group.md
@@ -1,0 +1,25 @@
+# UNSDG Classifier Technical Writers Focus Group
+
+## About
+This group supports contributors improving documentation, onboarding clarity, and technical content quality.
+
+## What this group works on
+- README and setup documentation improvements
+- API and workflow documentation updates
+- Contributor onboarding and support content
+
+## Meeting time
+- Bi-weekly project call: see calendar in the main README
+
+## Group leads
+- Project maintainers listed in the repository README
+
+## How to join
+1. Pick a documentation issue or propose one.
+2. Share the proposed structure before writing large changes.
+3. Submit concise, reviewer-friendly pull requests.
+
+## Suggested first tasks
+- Fix unclear setup instructions.
+- Add missing details for troubleshooting common errors.
+- Improve consistency and formatting in repository docs.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ David Lippert and Ruth Ikegah are co-chairs of the CHAOSS UN SDG working group. 
 
 Our project is officially listed in the [Code4GoodTech Dedicated Mentoring Program](https://codeforgoodtech.in/dedicated-mentoring-program/) for this summer 2026.  Please follow their process to apply for the single intern position.
 
+## Start Here
+
+If you are new to this repository, use this onboarding path:
+
+1. Join the bi-weekly call and introduce yourself.
+2. Pick a focus group that best matches your skills.
+3. Comment on an issue before starting work.
+4. Start with a small scoped contribution and ask for feedback early.
+
+### Focus Groups
+
+- [Developers Focus Group](./FOCUS%20GROUPS/developer-group.md)
+- [Designers Focus Group](./FOCUS%20GROUPS/designers-group.md)
+- [Community Managers Focus Group](./FOCUS%20GROUPS/communitymanagers-group.md)
+- [Research/Data Analysts Focus Group](./FOCUS%20GROUPS/researchers-group.md)
+- [Technical Writers Focus Group](./FOCUS%20GROUPS/technicalwriters-group.md)
+
 ## Features
 
 - 🔍 **Repository Analysis**: Analyzes GitHub repositories using AI to determine SDG alignment


### PR DESCRIPTION
## Summary
This PR improves contributor onboarding documentation by adding a clear entry path in the README and introducing standardized focus-group pages.

### What changed
- Added a **Start Here** onboarding section in `README.md`.
- Added direct links to all focus-group pages.
- Created standardized focus-group docs with consistent sections:
  - About
  - What this group works on
  - Meeting time
  - Group leads
  - How to join
  - Suggested first tasks

### Files added/updated
- `README.md`
- `FOCUS GROUPS/developer-group.md`
- `FOCUS GROUPS/designers-group.md`
- `FOCUS GROUPS/communitymanagers-group.md`
- `FOCUS GROUPS/researchers-group.md`
- `FOCUS GROUPS/technicalwriters-group.md`

## Why
New contributors need a clear “where to start” path.  
These changes reduce onboarding friction and make documentation more consistent across contributor groups.

## Validation
- Verified markdown formatting and internal links.
- Documentation-only change (no runtime/code behavior impact).

Closes #31