### PR TITLE
Fix tab switching with caching to avoid redundant API calls

### DIFF
--- a/frontend/components/results.tsx
+++ b/frontend/components/results.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { MdDone } from "react-icons/md";
 import { AiOutlineLoading3Quarters } from "react-icons/ai";
 import CardGrid from "./cardGrid";
@@ -28,11 +28,27 @@ const Results = ({ results, setResults, setError }: ResultsProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<string>("aurora");
   const [isLoadingTab, setIsLoadingTab] = useState(false);
+  const [modelResultsCache, setModelResultsCache] = useState<Record<string, ResultsData>>({});
+
+  //store initial data
+    useEffect(() => {
+    if (results && activeTab && !modelResultsCache[activeTab]) {
+      setModelResultsCache((prev) => ({
+        ...prev,
+        [activeTab]: results,
+      }));
+    }
+  }, [results]);
 
   const handleTabChange = async (newTab: string) => {
     if (newTab === activeTab || !results) return;
-
     setIsLoadingTab(true);
+    if (modelResultsCache[newTab]) {
+      setResults(modelResultsCache[newTab]);
+      setActiveTab(newTab);
+      setIsLoadingTab(false);
+      return;
+    }
     setActiveTab(newTab);
 
     const requestData = {
@@ -76,7 +92,15 @@ const Results = ({ results, setResults, setError }: ResultsProps) => {
       );
 
       if (response) {
-        setResults(response as ResultsData);
+        const typedResponse = response as ResultsData;
+
+        setResults(typedResponse);
+
+        // Store in cache
+        setModelResultsCache((prev) => ({
+          ...prev,
+          [newTab]: typedResponse,
+        }));
       }
     } catch (error) {
       console.error("Error fetching data for tab:", error);
@@ -93,11 +117,20 @@ const Results = ({ results, setResults, setError }: ResultsProps) => {
 
   const saveEditedResults = () => {
     if (results) {
-      setResults({
+      const updatedResults = {
         ...results,
         predictions: { ...(editableResults ?? {}) },
-      });
+      };
+
+      setResults(updatedResults);
+
+      // Update cache as well
+      setModelResultsCache((prev) => ({
+        ...prev,
+        [activeTab]: updatedResults,
+      }));
     }
+
     setIsModalOpen(false);
     setSaveMessage("SDG predictions updated successfully!");
 


### PR DESCRIPTION
## Description

This PR fixes an issue where switching between different models (Aurora, ST Description, ST URL) was causing repeated API calls and loss of previously fetched results.

---

## Problem

- Every time a user switched tabs, a new API request was sent  
- Previously fetched results were not preserved  
- This led to:
  - Slower performance  
  - Unnecessary backend load  
  - Poor user experience  

---

## Solution

- Added a **per-model caching system** using React state  
- Stored results for each model after the first API call  
- When switching tabs:
  - If data already exists → use cached results  
  - If not → fetch from API and store it  

---

## Improvements

- Avoids redundant API calls  
- Faster tab switching (instant if cached)  
- Preserves results for each model  
- Edited results are saved per tab  
- No breaking changes to existing functionality  

---

## Changes Made

- Added `modelResultsCache` state to store results per model  
- Updated `handleTabChange`:
  - Checks cache before making API call  
  - Stores new responses in cache  
- Updated `saveEditedResults`:
  - Syncs edited results with cache  
- Added `useEffect`:
  - Stores initial results in cache  
- Fixed loading state handling for cached data  

---

## Demo (Before vs After)


https://github.com/user-attachments/assets/8d533d10-5fcf-4f0c-ad8a-339e01c87164




https://github.com/user-attachments/assets/f896d6fe-dc64-475e-8246-5a4662deed72



---

## Result

- Tab switching is now smooth and instant after first load  
- No repeated API calls for the same model  
- Improved performance and user experience  