### PR TITLE
fix: require projectUrl for classify_st_url endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -124,32 +124,31 @@ def classify_st_url():
 
 
 
-     # 2. Sentence Transformer URL Model (GitHub URL-based)
+    # 2. Sentence Transformer URL Model (GitHub URL-based)
     print("\n===== RUNNING SENTENCE TRANSFORMER URL MODEL =====")
-    if projectUrl:
-        try:
-            st_url_result = classify_url(projectUrl)
+    if not projectUrl:
+        return jsonify({
+            'error': 'Project URL is required for URL-based classification'
+        }), 400
 
-            print("ST URL model completed successfully")
-        except ValueError as ve:
-            print(f"ST URL model invalid URL: {str(ve)}")
-            return jsonify({'error': str(ve)}), 400
-        except requests.exceptions.HTTPError as he:
-            print(f"ST URL model HTTP Error: {str(he)}")
-            return jsonify({
-                "error": f"Failed to fetch repository data. Please ensure the repository is public and exists. ({str(he)})",
-                "message": "Sentence Transformer URL model classification failed"
-            }), 400
-        except Exception as e:
-            print(f"ST URL model failed: {str(e)}")
-            return jsonify({
-                "error": str(e),
-                "message": "Sentence Transformer URL model classification failed"
-            }), 500
-    else:
-        st_url_result = {
-            "message": "No project URL provided, skipping URL-based classification"
-        }
+    try:
+        st_url_result = classify_url(projectUrl)
+        print("ST URL model completed successfully")
+    except ValueError as ve:
+        print(f"ST URL model invalid URL: {str(ve)}")
+        return jsonify({'error': str(ve)}), 400
+    except requests.exceptions.HTTPError as he:
+        print(f"ST URL model HTTP Error: {str(he)}")
+        return jsonify({
+            "error": f"Failed to fetch repository data. Please ensure the repository is public and exists. ({str(he)})",
+            "message": "Sentence Transformer URL model classification failed"
+        }), 400
+    except Exception as e:
+        print(f"ST URL model failed: {str(e)}")
+        return jsonify({
+            "error": str(e),
+            "message": "Sentence Transformer URL model classification failed"
+        }), 500
 
     preds = [
         {"sdg": name, "prediction": score}
@@ -157,10 +156,10 @@ def classify_st_url():
     ]
     filtered_predictions = [p for p in preds if p.get("prediction", 0) > 0.4]
     return jsonify({
-            "projectName": projectName,
-            "projectUrl": projectUrl,
-            "predictions": filtered_predictions,
-        }), 200
+        "projectName": projectName,
+        "projectUrl": projectUrl,
+        "predictions": filtered_predictions,
+    }), 200
 
 @app.route("/api/osdg_api", methods=["POST"])
 def osdg_external_api():


### PR DESCRIPTION
## Summary

The /api/classify_st_url endpoint was returning HTTP 200 with an empty predictions array when no projectUrl was provided, which is confusing to API consumers.

## Before (Issue)

When making a request without a projectUrl:

Request:
```
POST /api/classify_st_url
Content-Type: application/json

{
  "projectName": "Test Project",
  "projectDescription": "A test description"
}
```

Response (HTTP 200 OK):
```
{
  "projectName": "Test Project",
  "projectUrl": null,
  "predictions": []
}
```

Problems:
- HTTP 200 suggests success, but no predictions were made
- Empty predictions array with no explanation why
- API consumers might think this is a bug
- No clear indication that URL is required for URL-based classification

## After (Fixed)

Same request now returns:

Response (HTTP 400 Bad Request):
```
{
  "error": "Project URL is required for URL-based classification"
}
```

Benefits:
- Clear error message tells user exactly what is needed
- HTTP 400 indicates client error (missing required field)
- No confusing empty predictions array
- Aligns with endpoint name (URL-based classification)

## Changes Made

In backend/app.py, the classify_st_url function:

- Changed from conditional if/else block to early validation
- Removed the else branch that returned a message-only response
- Now returns 400 Bad Request immediately when projectUrl is missing
- Simplified control flow and removed dead code

The fix is minimal and focused on improving API usability through proper error handling.