### PR TITLE
feat: add Docker support for one-command local setup 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Python
+**/__pycache__
+**/*.py[cod]
+**/*.pyo
+**/.venv
+**/venv
+**/myvenv
+**/*.egg-info
+**/.pytest_cache
+
+# Node
+**/node_modules
+**/.next
+**/out
+**/build
+
+# Environment — never bake secrets into images
+**/.env
+**/.env.local
+
+# Version control and editor
+.git
+.gitignore
+.DS_Store
+.vscode
+.idea
+
+# macOS
+**/.DS_Store
+
+# Docs — not needed inside images
+*.md
+LICENSE

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in real values.
+# Never commit your actual .env file.
+
+# Required for GitHub URL-based classification (embedding_url.py)
+GITHUB_TOKEN=your_github_token_here
+
+# Required for OSDG external API classification (app.py)
+OSDG_TOKEN=your_osdg_token_here

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD ["python", "app.py"]
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,11 @@ app = Flask(__name__)
 CORS(app)
 
 
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({'status': 'ok'}), 200
+
+
 
 @app.route('/api/hello', methods=['GET'])
 def hello():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - FLASK_ENV=development
       - FLASK_DEBUG=1
+      - FLASK_APP=app.py
     volumes:
       - ./backend:/app
       - /app/__pycache__

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+# One-command local setup for UNSDG-classifier-tool
+#
+# Usage:
+#   cp backend/.env.example backend/.env
+#   # fill in GITHUB_TOKEN and OSDG_TOKEN in backend/.env
+#   docker compose up --build
+#
+# Frontend → http://localhost:3000
+# Backend  → http://localhost:5000
+
+services:
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "5000:5000"
+    env_file:
+      - ./backend/.env
+    environment:
+      - FLASK_ENV=development
+      - FLASK_DEBUG=1
+    volumes:
+      - ./backend:/app
+      - /app/__pycache__
+      - hf-model-cache:/root/.cache/huggingface
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:5000
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    depends_on:
+      backend:
+        condition: service_healthy
+
+volumes:
+  hf-model-cache:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -5,7 +5,7 @@ import {
   SDGClassificationResponse,
 } from "@/types/main";
 
-const API_BASE_URL = "http://127.0.0.1:5000/";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:5000/";
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
Closes #45

## Problem

Setting up this project locally requires contributors to manually install Python 3.8+, Node.js 18+, create a virtual environment, and run `bash.sh` — which doesn't work on Windows without WSL. Version mismatches cause hard-to-reproduce environment-specific bugs, creating friction especially during high-volume programs like DMP 2026.

## Solution

This PR adds full Docker Compose support so any contributor can get the
entire stack running with:

    cp backend/.env.example backend/.env
    # fill in GITHUB_TOKEN and OSDG_TOKEN
    docker compose up --build

Frontend → http://localhost:3000
Backend  → http://localhost:5000

---

## Files Added

| File | Purpose |
|---|---|
| `docker-compose.yml` | Orchestrates backend + frontend services |
| `backend/Dockerfile` | Python 3.11-slim image, installs requirements.txt |
| `frontend/Dockerfile` | Node 18 Alpine image, npm ci |
| `backend/.env.example` | Documents GITHUB_TOKEN and OSDG_TOKEN for contributors |
| `.dockerignore` | Excludes venv, node_modules, .env, .next from images |

## Code Changes

| File | Change |
|---|---|
| `backend/app.py` | Added `GET /health` route required by Docker healthcheck |
| `frontend/services/api.ts` | Backend URL now reads `NEXT_PUBLIC_API_URL` env var with fallback to `127.0.0.1:5000` so bare-metal workflow is unchanged |

---

## Design Decisions

**HuggingFace model cache** — `facebook/bart-large-mnli` and `sentence-transformers/all-MiniLM-L6-v2` are large models that download at runtime. A named volume `hf-model-cache` persists them across container restarts so they download only once.

**Flask bound to `0.0.0.0`** — Flask defaults to `127.0.0.1` which is unreachable from outside the container. The backend Dockerfile uses `flask run --host=0.0.0.0` to make it accessible on the Docker network.

**Volume mounts for live reload** — Source directories are mounted so code edits reflect immediately without rebuilding the image. Anonymous volumes guard `node_modules` and `__pycache__` from being shadowed by the host.

**`depends_on` with healthcheck** — The frontend waits for the backend `/health` route to return 200 before starting, preventing cold-start race conditions.

**Non-breaking fallback in api.ts** — The `??` operator means contributors not using Docker get the same `127.0.0.1:5000` behaviour as before. Zero regression for existing workflow.

---

## Testing Done

Tested locally on Windows 11 with Docker Desktop 27.4.0:

Level 1 — file verification
- All 5 new files confirmed present on disk
- `/health` route confirmed in backend/app.py line 17
- `NEXT_PUBLIC_API_URL` confirmed in frontend/services/api.ts line 8

Level 2 — image builds
- `docker build -t unsdg-backend ./backend` — 6/6 steps FINISHED
- `docker build -t unsdg-frontend ./frontend` — 12/12 steps FINISHED

Level 3 — full stack smoke test
- `curl http://localhost:5000/health` → `{"status": "ok"}` 200
- `curl http://localhost:5000/api/hello` → `{"message": "Hello, World!"}` 200
- Frontend verified loading correctly at http://localhost:3000

Level 4 — volume persistence
- `docker volume ls` confirms `unsdg-classifier-tool_hf-model-cache` present
- After `docker compose down && docker compose up`, backend reached healthy state instantly with no model re-download

---

## Notes

- Pairs naturally with #29 (env var refactor) — the `.env` file Docker needs is the same one that issue introduces
- No classification logic was changed in this PR
- The `bash.sh` workflow continues to work exactly as before for contributors who prefer not to use Docker