### PR TITLE
Add centralized reliability handling for Aurora and OSDG API integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,3 @@
-import os
 # import uuid
 # import json
 import requests
@@ -8,6 +7,8 @@ from datetime import datetime, UTC
 from embedding_description import main as classify_description
 from embedding_url import main as classify_url
 from aurora_api import main as aurora_classify
+from services.errors import UpstreamAPIError
+from services.external_apis import classify_with_osdg
 
 
 app = Flask(__name__)
@@ -43,6 +44,13 @@ def classify_aurora():
         )
 
         print("Aurora API model completed successfully")
+    except UpstreamAPIError as exc:
+        print(f"Aurora API upstream failure: {str(exc)}")
+        return jsonify({
+            "error": str(exc),
+            "message": "Aurora API classification failed",
+            "provider": exc.provider,
+        }), exc.status_code or 502
     except Exception as e:
         print(f"Aurora API model failed: {str(e)}")
         return jsonify({
@@ -172,21 +180,9 @@ def osdg_external_api():
     if not projectDescription:
         return jsonify({'error': 'Project description is required'}), 400
 
-    # Call the external OSDG API
     try:
-        osdg_response = requests.post(
-            "http://20.73.166.85/label_text",
-            json={
-                "text": projectDescription
-            },
-            headers={
-                "token": os.environ.get("OSDG_TOKEN")  # Ensure you have the OSDG token set in your environment variables
-            },
-            timeout=1000  # Set a timeout for the request
-        )
-        osdg_response.raise_for_status()  # Raise an error for bad status codes
-        osdg_result = osdg_response.json()
-    except requests.exceptions.RequestException as e:
+        osdg_result = classify_with_osdg(projectDescription)
+    except UpstreamAPIError as e:
         print(f"OSDG API request failed: {str(e)}")
         return jsonify({
             "error": f"Failed to connect to OSDG API: {str(e)}",

--- a/backend/aurora_api.py
+++ b/backend/aurora_api.py
@@ -1,6 +1,6 @@
-import requests
-import json
 from sdg_constants import SDG_LABELS_DICT as SDG_LABELS
+from services.errors import UpstreamAPIError
+from services.external_apis import classify_with_aurora
 
 
 def main(text: str, project_name: str = None, project_url: str = None):
@@ -16,13 +16,7 @@ def main(text: str, project_name: str = None, project_url: str = None):
         Dictionary with predictions in standardized format
     """
     try:
-        url = "https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi"
-        payload = json.dumps({"text": text})
-        headers = {'Content-Type': 'application/json'}
-        response = requests.request("POST", url, headers=headers, data=payload)
-        # response.raise_for_status()
-        
-        raw_result = response.json()
+        raw_result = classify_with_aurora(text)
         
         # Transform Aurora API response to match embedding model format
         # Aurora API can return different structures, handle both cases
@@ -90,15 +84,8 @@ def main(text: str, project_name: str = None, project_url: str = None):
         
         return formatted_result
         
-    except requests.exceptions.RequestException as e:
-       
-        return {
-            "project_name": project_name or "Unknown",
-            "project_url": project_url or "",
-            "sdg_predictions": {},
-            "error": str(e),
-            "message": "Aurora API request failed"
-        }
+    except UpstreamAPIError:
+        raise
     except Exception as e:
         return {
             "project_name": project_name or "Unknown",

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Small service helpers for backend integrations."""

--- a/backend/services/api_client.py
+++ b/backend/services/api_client.py
@@ -1,0 +1,97 @@
+import time
+
+import requests
+
+from services.errors import (
+    UpstreamAPIError,
+    UpstreamRateLimitError,
+    UpstreamResponseError,
+    UpstreamTimeoutError,
+)
+from services.rate_limiter import DEFAULT_RATE_LIMITER
+
+
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class APIClient:
+    """Small requests-based client with timeouts, retries, and local limiting."""
+
+    def __init__(
+        self,
+        timeout=10,
+        max_retries=2,
+        backoff_seconds=0.25,
+        rate_limiter=DEFAULT_RATE_LIMITER,
+        session=None,
+        sleeper=None,
+    ):
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.backoff_seconds = backoff_seconds
+        self.rate_limiter = rate_limiter
+        self.session = session or requests.Session()
+        self._sleep = sleeper or time.sleep
+
+    def request(self, method, url, provider, **kwargs):
+        if self.rate_limiter:
+            self.rate_limiter.check(provider)
+
+        request_timeout = kwargs.pop("timeout", self.timeout)
+        last_error = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    timeout=request_timeout,
+                    **kwargs,
+                )
+            except requests.exceptions.Timeout as exc:
+                last_error = UpstreamTimeoutError(
+                    f"{provider} request timed out",
+                    provider=provider,
+                )
+            except requests.exceptions.RequestException as exc:
+                last_error = UpstreamAPIError(
+                    f"{provider} request failed: {exc}",
+                    provider=provider,
+                )
+            else:
+                if response.status_code == 429:
+                    last_error = UpstreamRateLimitError(
+                        f"{provider} rate limit exceeded",
+                        provider=provider,
+                        status_code=response.status_code,
+                    )
+                elif response.status_code in RETRYABLE_STATUS_CODES:
+                    last_error = UpstreamAPIError(
+                        f"{provider} returned status {response.status_code}",
+                        provider=provider,
+                        status_code=response.status_code,
+                    )
+                elif response.status_code >= 400:
+                    raise UpstreamAPIError(
+                        f"{provider} returned status {response.status_code}",
+                        provider=provider,
+                        status_code=response.status_code,
+                    )
+                else:
+                    return response
+
+            if attempt < self.max_retries:
+                self._sleep(self.backoff_seconds * (2**attempt))
+
+        raise last_error
+
+    def request_json(self, method, url, provider, **kwargs):
+        response = self.request(method, url, provider, **kwargs)
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise UpstreamResponseError(
+                f"{provider} returned invalid JSON",
+                provider=provider,
+                status_code=response.status_code,
+            ) from exc

--- a/backend/services/errors.py
+++ b/backend/services/errors.py
@@ -1,0 +1,19 @@
+class UpstreamAPIError(Exception):
+    """Base exception for external API failures."""
+
+    def __init__(self, message, provider=None, status_code=None):
+        super().__init__(message)
+        self.provider = provider
+        self.status_code = status_code
+
+
+class UpstreamTimeoutError(UpstreamAPIError):
+    """Raised when an upstream API does not respond within the timeout."""
+
+
+class UpstreamRateLimitError(UpstreamAPIError):
+    """Raised when local or upstream rate limits are reached."""
+
+
+class UpstreamResponseError(UpstreamAPIError):
+    """Raised when an upstream API returns an invalid or unexpected response."""

--- a/backend/services/external_apis.py
+++ b/backend/services/external_apis.py
@@ -7,7 +7,9 @@ from services.errors import UpstreamResponseError
 AURORA_CLASSIFY_URL = (
     "https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi"
 )
-OSDG_LABEL_URL = "http://20.73.166.85/label_text"
+# Prefer an HTTPS OSDG endpoint when one is available; keep the current URL as
+# the fallback to preserve existing local behavior.
+OSDG_LABEL_URL = os.environ.get("OSDG_LABEL_URL", "http://20.73.166.85/label_text")
 
 _client = APIClient()
 

--- a/backend/services/external_apis.py
+++ b/backend/services/external_apis.py
@@ -1,0 +1,57 @@
+import os
+
+from services.api_client import APIClient
+from services.errors import UpstreamResponseError
+
+
+AURORA_CLASSIFY_URL = (
+    "https://aurora-sdg.labs.vu.nl/classifier/classify/elsevier-sdg-multi"
+)
+OSDG_LABEL_URL = "http://20.73.166.85/label_text"
+
+_client = APIClient()
+
+
+def classify_with_aurora(text, client=None):
+    api_client = client or _client
+    result = api_client.request_json(
+        "POST",
+        AURORA_CLASSIFY_URL,
+        provider="aurora",
+        json={"text": text},
+        headers={"Content-Type": "application/json"},
+    )
+
+    if not isinstance(result, dict):
+        raise UpstreamResponseError(
+            "Aurora returned an unexpected response",
+            provider="aurora",
+        )
+
+    predictions = result.get("predictions")
+    if predictions is not None and not isinstance(predictions, list):
+        raise UpstreamResponseError(
+            "Aurora predictions must be a list",
+            provider="aurora",
+        )
+
+    return result
+
+
+def classify_with_osdg(text, client=None):
+    api_client = client or _client
+    result = api_client.request_json(
+        "POST",
+        OSDG_LABEL_URL,
+        provider="osdg",
+        json={"text": text},
+        headers={"token": os.environ.get("OSDG_TOKEN", "")},
+    )
+
+    if not isinstance(result, (dict, list)):
+        raise UpstreamResponseError(
+            "OSDG returned an unexpected response",
+            provider="osdg",
+        )
+
+    return result

--- a/backend/services/rate_limiter.py
+++ b/backend/services/rate_limiter.py
@@ -1,0 +1,42 @@
+import threading
+import time
+from collections import deque
+
+from services.errors import UpstreamRateLimitError
+
+
+class InMemoryRateLimiter:
+    """Thread-safe sliding-window limiter for low-volume Flask deployments."""
+
+    def __init__(self, max_requests, window_seconds, clock=None):
+        if max_requests <= 0:
+            raise ValueError("max_requests must be greater than zero")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be greater than zero")
+
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._clock = clock or time.monotonic
+        self._requests = {}
+        self._lock = threading.Lock()
+
+    def check(self, key):
+        now = self._clock()
+        cutoff = now - self.window_seconds
+
+        with self._lock:
+            timestamps = self._requests.setdefault(key, deque())
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
+
+            if len(timestamps) >= self.max_requests:
+                raise UpstreamRateLimitError(
+                    "Rate limit exceeded. Please try again later.",
+                    provider=key,
+                    status_code=429,
+                )
+
+            timestamps.append(now)
+
+
+DEFAULT_RATE_LIMITER = InMemoryRateLimiter(max_requests=30, window_seconds=60)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_DIR))

--- a/backend/tests/test_api_client.py
+++ b/backend/tests/test_api_client.py
@@ -1,0 +1,131 @@
+import requests
+import pytest
+
+from services.api_client import APIClient
+from services.errors import (
+    UpstreamAPIError,
+    UpstreamRateLimitError,
+    UpstreamResponseError,
+    UpstreamTimeoutError,
+)
+from services.external_apis import classify_with_aurora
+from services.rate_limiter import InMemoryRateLimiter
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, json_error=None):
+        self.status_code = status_code
+        self._payload = payload
+        self._json_error = json_error
+
+    def json(self):
+        if self._json_error:
+            raise self._json_error
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def make_client(outcomes, rate_limiter=None):
+    return APIClient(
+        timeout=1,
+        max_retries=2,
+        backoff_seconds=0,
+        rate_limiter=rate_limiter,
+        session=FakeSession(outcomes),
+        sleeper=lambda seconds: None,
+    )
+
+
+def test_retries_retryable_status_then_returns_json():
+    client = make_client([
+        FakeResponse(status_code=503),
+        FakeResponse(status_code=200, payload={"ok": True}),
+    ])
+
+    result = client.request_json("POST", "https://example.test", provider="aurora")
+
+    assert result == {"ok": True}
+    assert len(client.session.calls) == 2
+
+
+def test_retry_backoff_uses_exponential_delays():
+    delays = []
+    client = APIClient(
+        timeout=1,
+        max_retries=2,
+        backoff_seconds=0.25,
+        rate_limiter=None,
+        session=FakeSession([
+            FakeResponse(status_code=503),
+            FakeResponse(status_code=503),
+            FakeResponse(status_code=503),
+        ]),
+        sleeper=delays.append,
+    )
+
+    with pytest.raises(UpstreamAPIError):
+        client.request("POST", "https://example.test", provider="aurora")
+
+    assert delays == [0.25, 0.5]
+
+
+def test_timeout_raises_typed_exception_after_retries():
+    client = make_client([
+        requests.exceptions.Timeout("slow"),
+        requests.exceptions.Timeout("still slow"),
+        requests.exceptions.Timeout("done"),
+    ])
+
+    with pytest.raises(UpstreamTimeoutError):
+        client.request("GET", "https://example.test", provider="aurora")
+
+    assert len(client.session.calls) == 3
+
+
+def test_rate_limiter_blocks_after_limit():
+    now = [100.0]
+    limiter = InMemoryRateLimiter(max_requests=1, window_seconds=60, clock=lambda: now[0])
+
+    limiter.check("osdg")
+
+    with pytest.raises(UpstreamRateLimitError):
+        limiter.check("osdg")
+
+
+def test_non_retryable_http_error_is_typed():
+    client = make_client([FakeResponse(status_code=400)])
+
+    with pytest.raises(UpstreamAPIError) as exc_info:
+        client.request("POST", "https://example.test", provider="osdg")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_invalid_json_raises_response_error():
+    client = make_client([
+        FakeResponse(status_code=200, json_error=ValueError("bad json")),
+    ])
+
+    with pytest.raises(UpstreamResponseError):
+        client.request_json("GET", "https://example.test", provider="aurora")
+
+
+def test_aurora_wrapper_rejects_invalid_predictions_shape():
+    client = make_client([
+        FakeResponse(status_code=200, payload={"predictions": {"bad": "shape"}}),
+    ])
+
+    with pytest.raises(UpstreamResponseError):
+        classify_with_aurora("sample text", client=client)


### PR DESCRIPTION
## Summary

This PR introduces a focused backend reliability layer for external Aurora and OSDG API integrations.

The goal is to improve resilience around upstream API interactions while preserving existing frontend contracts and application behavior.

## Why

The current backend integrations with Aurora and OSDG rely on direct upstream API calls with limited retry, timeout, and resilience handling.

This PR introduces a small centralized reliability layer to improve:

* resilience against transient upstream failures,
* safer handling of rate-limited providers,
* and consistency of external API interactions,

while intentionally preserving the existing frontend/API behavior and keeping the implementation modular.

## What this PR adds

* centralized API request handling
* retry + exponential backoff for transient upstream failures
* practical timeout handling
* lightweight in-memory rate limiting
* typed upstream exceptions
* provider-specific API wrappers
* minimal no-network pytest coverage

## Scope intentionally avoided

To keep this PR modular and reviewable, this does NOT include:

* frontend changes
* deployment/CI updates
* Flask architecture rewrites
* async workers/queues
* ML pipeline refactors
* response schema redesigns
* Redis/Celery/background job systems

## Files added

* `backend/services/errors.py`
* `backend/services/rate_limiter.py`
* `backend/services/api_client.py`
* `backend/services/external_apis.py`

## Integration updates

* `backend/aurora_api.py`
* `backend/app.py`

## Tests

Added isolated pytest coverage for:

* retry behavior
* timeout handling
* rate limiting
* invalid upstream responses
* typed exception handling

## Verification

Executed successfully:

```bash
python -m pytest backend/tests
python -m compileall backend
```

Result:

* 7 tests passed

## Notes

This PR intentionally keeps the implementation small and focused to avoid overlap with existing deployment, frontend caching, logging, and response-standardization work already being discussed in the repository.