### PR TITLE
feat: make frontend backend API URL configurable via environment variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Backend API base URL
+# Override for deployed/staging environments (e.g., PythonAnywhere).
+# Defaults to http://127.0.0.1:5000/ for local development.
+NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:5000/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -31,7 +31,11 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.example
+.env.local
+.env.development
+.env.production
+.env
 
 # vercel
 .vercel

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -5,7 +5,8 @@ import {
   SDGClassificationResponse,
 } from "@/types/main";
 
-const API_BASE_URL = "http://127.0.0.1:5000/";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:5000/";
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary

The frontend `api.ts` hardcodes the backend API URL as `http://127.0.0.1:5000/`, which prevents deployment to hosted environments where the backend runs at a different origin (e.g., PythonAnywhere).

This PR makes the URL configurable via the `NEXT_PUBLIC_API_BASE_URL` environment variable, falling back to the local default when unset.

Related to #8 – deployment readiness.

## Changes

- **`frontend/services/api.ts`**: Read `NEXT_PUBLIC_API_BASE_URL` from `process.env` with fallback to `http://127.0.0.1:5000/`
- **`frontend/.env.example`**: Document the new variable
- **`frontend/.gitignore`**: Explicitly list env files (instead of broad `.env*` glob) so `.env.example` can be committed

## Usage

Local development (default -- no action needed):

    npm run dev

Point at a deployed backend:

    cp frontend/.env.example frontend/.env.local
    # Edit NEXT_PUBLIC_API_BASE_URL in .env.local
    npm run dev
