### PR TITLE
Docs/testing guide

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ flask
 flask-cors
 Flask-UUID
 markdowncleaner
+pytest

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SERVICES_DIR = os.path.join(BACKEND_DIR, "services")
+
+for path in (BACKEND_DIR, SERVICES_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+# test_dpga_real_positives.py and test_gitlab_provider.py are manual,
+# live-network verification scripts (see docs/TESTING.md), not pytest
+# suites. Importing them during collection would pull in heavy ML deps
+# (transformers, sentence-transformers) and dotenv that aren't needed to
+# run the real automated tests.
+collect_ignore = [
+    "test_dpga_real_positives.py",
+    "test_gitlab_provider.py",
+]

--- a/backend/tests/test_dpga_real_positives.py
+++ b/backend/tests/test_dpga_real_positives.py
@@ -6,10 +6,15 @@ from DPGA registry spreadsheet (single-SDG-tagged entries only, for
 clean signal). Compare predicted vs ground truth, compute COSINE_LOW/HIGH.
 """
 
+import os
+import sys
 import requests
 import numpy as np
 import time
 import re
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 import sdg_constants
 from embedding_url import get_embedder
 

--- a/backend/tests/test_gitlab_provider.py
+++ b/backend/tests/test_gitlab_provider.py
@@ -1,4 +1,8 @@
+import os
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "services"))
+
 from repo_fetcher import get_provider, ProviderError
 
 GITLAB_TARGETS = [

--- a/backend/tests/test_repo_fetcher.py
+++ b/backend/tests/test_repo_fetcher.py
@@ -1,0 +1,501 @@
+"""
+Unit tests for backend/services/repo_fetcher.py.
+
+No real network access — every HTTP call goes through a mocked
+`requests.get`, so these run fully offline and fast. See docs/TESTING.md
+§1 for the coverage checklist this file implements.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+import repo_fetcher
+from repo_fetcher import (
+    BitbucketProvider,
+    CodebergProvider,
+    FetchError,
+    GitHubProvider,
+    GitLabProvider,
+    InvalidURLError,
+    RateLimitError,
+    RepositoryNotFoundError,
+    SUPPORTED_HOSTS,
+    UnsupportedHostError,
+    _detect_engine,
+    _rewrite_github_pages,
+    _sanitise_url,
+    get_provider,
+)
+
+
+def _mock_response(status_code=200, json_data=None, text="", headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.headers = headers or {}
+    resp.json = MagicMock(return_value=json_data if json_data is not None else {})
+    if status_code >= 400:
+        resp.raise_for_status = MagicMock(
+            side_effect=requests.HTTPError(f"{status_code} error")
+        )
+    else:
+        resp.raise_for_status = MagicMock(return_value=None)
+    return resp
+
+
+# ─────────────────────────── _sanitise_url ───────────────────────────────────
+
+class TestSanitiseUrl:
+    def test_valid_url_is_stripped(self):
+        assert _sanitise_url("  https://github.com/owner/repo  ") == (
+            "https://github.com/owner/repo"
+        )
+
+    def test_valid_bytes_decoded(self):
+        assert _sanitise_url(b"https://github.com/owner/repo") == (
+            "https://github.com/owner/repo"
+        )
+
+    def test_invalid_utf8_bytes_raise(self):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url(b"\xff\xfe")
+
+    @pytest.mark.parametrize("bad", [None, 123, ["a"], {"a": 1}])
+    def test_non_string_types_raise(self, bad):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url(bad)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    def test_empty_or_whitespace_raises(self, bad):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url(bad)
+
+    def test_no_scheme_raises(self):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url("owner/repo")
+
+    @pytest.mark.parametrize("scheme", ["ftp", "git", "ssh"])
+    def test_non_http_scheme_raises(self, scheme):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url(f"{scheme}://github.com/owner/repo")
+
+    def test_missing_hostname_raises(self):
+        with pytest.raises(InvalidURLError):
+            _sanitise_url("https:///owner/repo")
+
+
+# ─────────────────────────── _rewrite_github_pages ───────────────────────────
+
+class TestRewriteGithubPages:
+    def test_root_pages_site_maps_to_owner_dot_github_io_repo(self):
+        assert _rewrite_github_pages("https://emapr.github.io") == (
+            "https://github.com/emapr/emapr.github.io"
+        )
+
+    def test_project_pages_site(self):
+        assert _rewrite_github_pages("https://owner.github.io/repo") == (
+            "https://github.com/owner/repo"
+        )
+
+    def test_project_pages_site_deep_link(self):
+        assert _rewrite_github_pages("https://owner.github.io/repo/sub/path") == (
+            "https://github.com/owner/repo"
+        )
+
+    def test_non_pages_url_unchanged(self):
+        url = "https://github.com/owner/repo"
+        assert _rewrite_github_pages(url) == url
+
+
+# ─────────────────────────── provider _parse ─────────────────────────────────
+
+class TestGitHubParse:
+    def test_valid_owner_repo(self):
+        p = GitHubProvider("https://github.com/torvalds/linux")
+        assert (p._owner, p._repo) == ("torvalds", "linux")
+
+    def test_strips_dot_git_suffix(self):
+        p = GitHubProvider("https://github.com/torvalds/linux.git")
+        assert p._repo == "linux"
+
+    def test_missing_repo_segment_raises(self):
+        with pytest.raises(InvalidURLError):
+            GitHubProvider("https://github.com/torvalds")
+
+    def test_invalid_characters_raise(self):
+        with pytest.raises(InvalidURLError):
+            GitHubProvider("https://github.com/owner/repo with spaces")
+
+
+class TestGitLabParse:
+    def test_valid_owner_repo(self):
+        p = GitLabProvider("https://gitlab.com/gitlab-org/gitlab")
+        assert (p._owner, p._repo) == ("gitlab-org", "gitlab")
+
+    def test_nested_subgroups(self):
+        p = GitLabProvider("https://gitlab.com/group/subgroup/project")
+        assert (p._owner, p._repo) == ("group/subgroup", "project")
+
+    def test_strips_dot_git_suffix(self):
+        p = GitLabProvider("https://gitlab.com/group/project.git")
+        assert p._repo == "project"
+
+    def test_missing_repo_segment_raises(self):
+        with pytest.raises(InvalidURLError):
+            GitLabProvider("https://gitlab.com/onlyowner")
+
+    def test_encoded_path_escapes_slashes(self):
+        p = GitLabProvider("https://gitlab.com/group/subgroup/project")
+        assert p._encoded_path() == "group%2Fsubgroup%2Fproject"
+
+    def test_self_hosted_api_base_derived_from_host(self):
+        p = GitLabProvider("https://framagit.org/group/project")
+        assert p._API == "https://framagit.org/api/v4"
+
+
+class TestCodebergParse:
+    def test_valid_owner_repo(self):
+        p = CodebergProvider("https://codeberg.org/forgejo/forgejo")
+        assert (p._owner, p._repo) == ("forgejo", "forgejo")
+
+    def test_missing_repo_segment_raises(self):
+        with pytest.raises(InvalidURLError):
+            CodebergProvider("https://codeberg.org/onlyowner")
+
+
+class TestBitbucketParse:
+    def test_valid_workspace_repo_slug(self):
+        p = BitbucketProvider("https://bitbucket.org/cioapps/wapor-et-look")
+        assert (p._owner, p._repo) == ("cioapps", "wapor-et-look")
+        assert p._is_wiki_url is False
+
+    def test_wiki_url_detected(self):
+        p = BitbucketProvider("https://bitbucket.org/cioapps/wapor-et-look/wiki/Home")
+        assert p._is_wiki_url is True
+
+    def test_missing_repo_segment_raises(self):
+        with pytest.raises(InvalidURLError):
+            BitbucketProvider("https://bitbucket.org/onlyworkspace")
+
+
+# ─────────────────────────── _raise_for_status / _get ────────────────────────
+
+class TestRaiseForStatusAndGet:
+    """Exercised through GitHubProvider._get since the logic lives on the
+    shared BaseRepositoryProvider and GitHubProvider is a concrete stand-in."""
+
+    def _provider(self):
+        return GitHubProvider("https://github.com/owner/repo")
+
+    def test_200_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(200)))
+        r = self._provider()._get("http://x", context="ctx")
+        assert r.status_code == 200
+
+    def test_404_raises_repository_not_found(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(404)))
+        with pytest.raises(RepositoryNotFoundError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_429_raises_rate_limit_with_retry_after(self, monkeypatch):
+        resp = _mock_response(429, headers={"Retry-After": "42"})
+        monkeypatch.setattr(repo_fetcher.requests, "get", MagicMock(return_value=resp))
+        with pytest.raises(RateLimitError, match="42"):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_403_with_rate_limit_body_raises_rate_limit(self, monkeypatch):
+        resp = _mock_response(403, text="Secondary Rate Limit exceeded")
+        monkeypatch.setattr(repo_fetcher.requests, "get", MagicMock(return_value=resp))
+        with pytest.raises(RateLimitError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_401_raises_fetch_error(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(401)))
+        with pytest.raises(FetchError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_403_without_rate_limit_body_raises_fetch_error(self, monkeypatch):
+        resp = _mock_response(403, text="Forbidden: private repository")
+        monkeypatch.setattr(repo_fetcher.requests, "get", MagicMock(return_value=resp))
+        with pytest.raises(FetchError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_other_error_code_raises_fetch_error(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(500)))
+        with pytest.raises(FetchError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_connection_error_wrapped_as_fetch_error(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError()),
+        )
+        with pytest.raises(FetchError):
+            self._provider()._get("http://x", context="ctx")
+
+    def test_timeout_wrapped_as_fetch_error(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=requests.exceptions.Timeout()),
+        )
+        with pytest.raises(FetchError):
+            self._provider()._get("http://x", context="ctx")
+
+
+# ─────────────────────────── GitHubProvider fetch_* ──────────────────────────
+
+class TestGitHubFetch:
+    def _provider(self):
+        return GitHubProvider("https://github.com/owner/repo")
+
+    def test_fetch_readme_returns_text(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, text="# Hello")),
+        )
+        assert self._provider().fetch_readme() == "# Hello"
+
+    def test_fetch_readme_missing_returns_empty_string(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(404)))
+        assert self._provider().fetch_readme() == ""
+
+    def test_fetch_topics(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={"topics": ["a", "b"]})),
+        )
+        assert self._provider().fetch_topics() == ["a", "b"]
+
+    def test_fetch_meta(self, monkeypatch):
+        json_data = {"name": "repo", "description": "desc", "homepage": "http://x"}
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data=json_data)),
+        )
+        assert self._provider().fetch_meta() == json_data
+
+
+# ─────────────────────────── GitLabProvider fetch_* ──────────────────────────
+
+class TestGitLabFetch:
+    def _provider(self):
+        return GitLabProvider("https://gitlab.com/group/project")
+
+    def test_fetch_readme_uses_filename_from_readme_url(self, monkeypatch):
+        meta_resp = _mock_response(
+            200,
+            json_data={"readme_url": "https://gitlab.com/g/p/-/blob/main/README.rst"},
+        )
+        raw_resp = _mock_response(200, text="Gitlab readme content")
+        mock_get = MagicMock(side_effect=[meta_resp, raw_resp])
+        monkeypatch.setattr(repo_fetcher.requests, "get", mock_get)
+
+        assert self._provider().fetch_readme() == "Gitlab readme content"
+        second_call_url = mock_get.call_args_list[1].args[0]
+        assert "README.rst" in second_call_url
+
+    def test_fetch_readme_project_not_found_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(404)))
+        assert self._provider().fetch_readme() == ""
+
+    def test_readme_filename_defaults_to_readme_md(self):
+        p = self._provider()
+        assert p._readme_filename({}) is None
+
+    def test_fetch_topics(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={"topics": ["x"]})),
+        )
+        assert self._provider().fetch_topics() == ["x"]
+
+
+# ─────────────────────────── CodebergProvider fetch_* ────────────────────────
+
+class TestCodebergFetch:
+    def _provider(self):
+        return CodebergProvider("https://codeberg.org/forgejo/forgejo")
+
+    def test_fetch_readme_first_filename_succeeds(self, monkeypatch):
+        branch_resp = _mock_response(200, json_data={"default_branch": "main"})
+        readme_resp = _mock_response(200, text="Codeberg readme")
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=[branch_resp, readme_resp]),
+        )
+        assert self._provider().fetch_readme() == "Codeberg readme"
+
+    def test_default_branch_falls_back_to_main_on_error(self, monkeypatch):
+        branch_resp = _mock_response(500)
+        readme_resp = _mock_response(200, text="content")
+        mock_get = MagicMock(side_effect=[branch_resp, readme_resp])
+        monkeypatch.setattr(repo_fetcher.requests, "get", mock_get)
+
+        assert self._provider().fetch_readme() == "content"
+        second_call_params = mock_get.call_args_list[1].kwargs.get("params")
+        assert second_call_params == {"ref": "main"}
+
+    def test_fetch_readme_all_filenames_missing_returns_empty(self, monkeypatch):
+        branch_resp = _mock_response(200, json_data={"default_branch": "main"})
+        not_found = _mock_response(404)
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=[branch_resp, not_found, not_found, not_found, not_found]),
+        )
+        assert self._provider().fetch_readme() == ""
+
+    def test_fetch_topics(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={"topics": ["y"]})),
+        )
+        assert self._provider().fetch_topics() == ["y"]
+
+    def test_fetch_topics_not_found_returns_empty_list(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(404)))
+        assert self._provider().fetch_topics() == []
+
+
+# ─────────────────────────── BitbucketProvider fetch_* ───────────────────────
+
+class TestBitbucketFetch:
+    def _provider(self, url="https://bitbucket.org/cioapps/wapor-et-look"):
+        return BitbucketProvider(url)
+
+    def test_fetch_readme_uses_mainbranch_name(self, monkeypatch):
+        meta_resp = _mock_response(200, json_data={"mainbranch": {"name": "develop"}})
+        readme_resp = _mock_response(200, text="Bitbucket readme")
+        mock_get = MagicMock(side_effect=[meta_resp, readme_resp])
+        monkeypatch.setattr(repo_fetcher.requests, "get", mock_get)
+
+        assert self._provider().fetch_readme() == "Bitbucket readme"
+        second_call_url = mock_get.call_args_list[1].args[0]
+        assert "/src/develop/README.md" in second_call_url
+
+    def test_fetch_readme_repo_not_found_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher.requests, "get",
+                             MagicMock(return_value=_mock_response(404)))
+        assert self._provider().fetch_readme() == ""
+
+    def test_fetch_readme_falls_back_to_wiki_home(self, monkeypatch):
+        meta_resp = _mock_response(200, json_data={"mainbranch": {"name": "master"}})
+        not_found = _mock_response(404)
+        wiki_resp = _mock_response(200, text="Wiki home content")
+        mock_get = MagicMock(
+            side_effect=[meta_resp, not_found, not_found, not_found, not_found, wiki_resp]
+        )
+        monkeypatch.setattr(repo_fetcher.requests, "get", mock_get)
+
+        provider = self._provider(
+            "https://bitbucket.org/cioapps/wapor-et-look/wiki/Home"
+        )
+        assert provider.fetch_readme() == "Wiki home content"
+
+    def test_fetch_topics_returns_language_as_single_item_list(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={"language": "python"})),
+        )
+        assert self._provider().fetch_topics() == ["python"]
+
+    def test_fetch_topics_empty_when_no_language(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={})),
+        )
+        assert self._provider().fetch_topics() == []
+
+    def test_fetch_meta_homepage_always_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(
+                200, json_data={"name": "repo", "description": "desc"}
+            )),
+        )
+        meta = self._provider().fetch_meta()
+        assert meta == {"name": "repo", "description": "desc", "homepage": ""}
+
+
+# ─────────────────────────── _detect_engine ──────────────────────────────────
+
+class TestDetectEngine:
+    def test_gitlab_probe_succeeds(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(200, json_data={"version": "16.0"})),
+        )
+        assert _detect_engine("git.example.org") is GitLabProvider
+
+    def test_gitlab_fails_gitea_probe_succeeds(self, monkeypatch):
+        gitlab_fail = requests.exceptions.RequestException("no gitlab here")
+        gitea_ok = _mock_response(200, json_data={"version": "1.20"})
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=[gitlab_fail, gitea_ok]),
+        )
+        assert _detect_engine("git.example.org") is CodebergProvider
+
+    def test_neither_probe_matches_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(return_value=_mock_response(404)),
+        )
+        assert _detect_engine("git.example.org") is None
+
+    def test_network_failures_are_swallowed(self, monkeypatch):
+        monkeypatch.setattr(
+            repo_fetcher.requests, "get",
+            MagicMock(side_effect=requests.exceptions.ConnectionError()),
+        )
+        assert _detect_engine("git.example.org") is None
+
+
+# ─────────────────────────── get_provider factory ────────────────────────────
+
+class TestGetProviderFactory:
+    def test_known_domain_routes_without_network_call(self, monkeypatch):
+        mock_get = MagicMock()
+        monkeypatch.setattr(repo_fetcher.requests, "get", mock_get)
+
+        provider = get_provider("https://github.com/torvalds/linux")
+
+        assert isinstance(provider, GitHubProvider)
+        mock_get.assert_not_called()
+
+    def test_self_hosted_gitlab_domain_derives_api_base(self):
+        provider = get_provider("https://framagit.org/group/project")
+        assert isinstance(provider, GitLabProvider)
+        assert provider._API == "https://framagit.org/api/v4"
+
+    def test_github_pages_url_rewritten_before_routing(self):
+        provider = get_provider("https://owner.github.io/repo")
+        assert isinstance(provider, GitHubProvider)
+        assert (provider._owner, provider._repo) == ("owner", "repo")
+
+    def test_unregistered_host_falls_through_to_detect_engine(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher, "_detect_engine", lambda host: GitLabProvider)
+        provider = get_provider("https://git.unknown-forge.example/group/project")
+        assert isinstance(provider, GitLabProvider)
+
+    def test_unsupported_host_raises_with_supported_hosts_listed(self, monkeypatch):
+        monkeypatch.setattr(repo_fetcher, "_detect_engine", lambda host: None)
+        with pytest.raises(UnsupportedHostError) as exc_info:
+            get_provider("https://example.com/owner/repo")
+        assert SUPPORTED_HOSTS[0] in str(exc_info.value)
+
+    def test_invalid_input_raises_invalid_url_error(self):
+        with pytest.raises(InvalidURLError):
+            get_provider(None)
+
+    def test_token_passed_through_to_provider(self):
+        provider = get_provider("https://github.com/owner/repo", token="secret-token")
+        assert provider.token == "secret-token"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,127 @@
+# Testing Guide
+
+This document inventories the testing this project needs: what exists today, what's missing, and the specific test cases each module should have. It's meant to guide contributors picking up `test/` issues, not to describe tests that already exist — as of this writing, **no test framework is installed** in either the backend or the frontend (`frontend/package.json` has no test runner, and the backend has no `pytest`/`unittest` setup). The two files under [`backend/tests/`](../backend/tests/) are manual verification scripts, not an automated suite.
+
+## Current **state**
+
+| Area | Test runner | Status |
+|------|-------------|--------|
+| Backend (`backend/`) | none | No framework installed. `backend/tests/test_dpga_real_positives.py` and `backend/tests/test_gitlab_provider.py` are manual scripts you run by hand against a live server — useful as smoke tests, not part of CI. |
+| ML microservice (`models/`) | none | No tests. Model loads real weights from Hugging Face Hub at import time, which makes naive unit testing hard (see [§7](#7-models--ge-lab-microservice)). |
+| Frontend (`frontend/`) | none | No Jest/Vitest/React Testing Library installed. `npm run lint` is the only check that runs today. |
+
+Setting up the runners themselves (`pytest` for backend/models, `Jest` + `React Testing Library` for frontend) is a prerequisite for most of the work below and is good first-issue material.
+
+### Known gap this inventory surfaced (resolved)
+
+While reviewing the code to write this guide, [`frontend/services/api.ts`](../frontend/services/api.ts) was found to call `api/classify_st_description`, but [`backend/app.py`](../backend/app.py) only defines `/api/hello`, `/api/classify_aurora`, and `/api/classify_st_url` — the description-only classification route never existed on the backend, so selecting the corresponding tab in the UI would fail. Rather than adding the missing route, the dead frontend call was removed: `sdgApi.classifySTDescription`, the `"st-description"` case in `classifyByModel`, and the "Sentence Transformer Description" tab in `results.tsx` are gone. Only `"aurora"` and `"st-url"` are valid `classifyByModel` model types now. A contract test between the frontend API client and the backend routes (§9) would catch this class of drift automatically in the future.
+
+---
+
+## 1. `backend/services/repo_fetcher.py`
+
+Highest priority — this module is pure logic with a deliberate exception hierarchy, and needs no ML model or live network access if `requests` is mocked.
+
+- **`_sanitise_url`**: bytes input (valid UTF-8 and invalid), non-string types (`None`, `int`, `list`, `dict`), empty/whitespace-only string, missing scheme, non-http(s) scheme (`ftp://`, `git://`, `ssh://`), missing hostname.
+- **`_rewrite_github_pages`**: root `*.github.io` (no path), `*.github.io/repo`, `*.github.io/repo/deep/path`, non-Pages URLs pass through unchanged.
+- **Provider `_parse` methods**: valid `owner/repo`, missing segments, `.git` suffix stripping, invalid characters (GitHub's segment regex), nested subgroups (GitLab), `/wiki/` path detection (Bitbucket).
+- **`_raise_for_status`**: 200 (no raise), 404 → `RepositoryNotFoundError`, 429 → `RateLimitError`, 403 with "rate limit" in body → `RateLimitError`, 401 → `FetchError`, other 403 → `FetchError`, other status codes → `FetchError`.
+- **`fetch_readme` / `fetch_topics` / `fetch_meta`** per provider (GitHub, GitLab, Codeberg, Bitbucket), with mocked HTTP responses — including the "repo has no README" case, which must return `""`, not raise.
+- **`_detect_engine`**: GitLab probe succeeds, Gitea/Forgejo probe succeeds, both fail → `None`, network exceptions during probing are swallowed rather than propagated.
+- **`get_provider` factory**: known domain resolves without a network call, unknown domain triggers engine detection, unsupported host raises `UnsupportedHostError` with the expected message, token is passed through to the provider.
+
+## 2. `backend/embedding_url.py`
+
+- **`fetch_repo_text`**: user-supplied `project_description` takes priority over the repo's own metadata description (the documented "CHANGE 2" behavior); provider errors on `fetch_meta`/`fetch_topics`/`fetch_readme` are caught individually and don't abort the whole call.
+- **`zero_shot_scores`**: score ordering matches `SDG_NAMES`; raises `KeyError` when the microservice response is missing expected keys; raises `TypeError` on an unexpected `scores` type; handles the `payload["data"]["scores"]` nested-response shape.
+- **`embedding_similarity_scores`**: output is clipped to `[0, 1]` via `COSINE_LOW`/`COSINE_HIGH`.
+- **`ensemble_scores`**: weighted-average arithmetic is correct for various `alpha` values.
+- **`classify_repo`**: empty extracted text raises `ValueError`; predictions above `threshold` are selected; falls back to the top 3 ranked SDGs when nothing clears the threshold.
+- **`main`**: scores are formatted to 3 decimal places in the output dict.
+
+All of the above need `requests`, `get_provider`, `summarize_for_sdg`, and `SentenceTransformer` mocked — none of these are integration tests against a live model or network.
+
+## 3. `backend/aurora_api.py`
+
+Table-driven tests against fixture Aurora API payloads:
+
+- `sdg` as a dict with a `code` field → formatted as `"SDG {code}: {name}"`.
+- `sdg` present but missing `code` → falls back to `name`/`label`.
+- `sdg` field missing entirely → falls back to `pred.get("label")`/`pred.get("name")`/`pred.get("sdg_label")`.
+- Score at or below the `0.1` cutoff is excluded from `sdg_predictions`.
+- `requests.exceptions.RequestException` → returns the documented error dict, doesn't raise.
+- A generic `Exception` during processing → returns the documented error dict, doesn't raise.
+
+## 4. `backend/services/summariser.py`
+
+- **`_prepare_for_llm`**: code fences removed, badge/shield images stripped, generic markdown images collapsed to alt text, HTML comments and tags stripped, bare URLs stripped, `max_chars` truncation applied.
+- **`_validate_output`**: banned openers ("here is", "this project", "the repository", …) are stripped from the first line; output over 200 words is truncated at a sentence boundary.
+- **`_fallback_summary`**: assembles from whatever combination of name/description/topics/reason is present; returns `""` when all inputs are empty.
+- **`summarize_for_sdg`**:
+  - No `GROQ_API_KEY` → falls back immediately, no network call.
+  - Groq returns HTTP 200 with an `"error"` key in the body → falls back (this path is easy to miss since `raise_for_status()` alone won't catch it — worth its own explicit test).
+  - Empty `choices` list → falls back.
+  - `requests.exceptions.Timeout` / `HTTPError` / `RequestException` → falls back in each case.
+  - Malformed `choices[0]["message"]` shape → falls back via the `KeyError`/`IndexError` branch.
+
+Mock `requests.post`; no real Groq API calls in the unit suite.
+
+## 5. `backend/sdg_constants.py`
+
+Data-integrity checks rather than behavior:
+
+- `len(SDG_NAMES) == len(SDG_DESCS) == len(SDG_LABELS) == 17`.
+- Each entry in `SDG_NAMES` and `SDG_DESCS` starts with the correct `SDG {n}` number, in order.
+- `SDG_LABELS_DICT` has exactly the keys `"1"` through `"17"`.
+
+Cheap to write, and catches silent data-entry drift if someone edits the SDG text by hand. (Note: the trailing `SDGs = ["SDG 1", "SDG 2", "SDG 3"]` at the bottom of the file looks like dead code left over from development — worth confirming with a maintainer and removing rather than testing.)
+
+## 6. `backend/app.py` (Flask routes)
+
+Integration-style tests using Flask's test client (no live server needed):
+
+- `POST /api/classify_aurora`: missing `projectDescription` → `400`; happy path filters predictions to `> 0.4`; an exception from `aurora_classify` → `500` with the documented error shape.
+- `POST /api/classify_st_url`: missing `projectDescription` → `400`; missing `projectUrl` → `200` with empty `predictions` and an explanatory `message`; each of `InvalidURLError`/`UnsupportedHostError`/`ValueError` → `400`, `RepositoryNotFoundError` → `404`, `RateLimitError` → `429`, `FetchError`/`requests.exceptions.HTTPError` → `502`, anything else → `500`. This status-code mapping is exactly the kind of thing that silently breaks during a refactor if it isn't pinned down by a test.
+- No `/api/classify_st_description` route exists, and no frontend code calls it anymore (see [gap above](#known-gap-this-inventory-surfaced-resolved)) — nothing to test here unless the route is intentionally reintroduced later.
+- CORS headers are present on responses.
+
+## 7. `models/` (GE-Lab microservice)
+
+The hardest area to unit test conventionally: `classifier.py` and `models/app.py` load real weights from the Hugging Face Hub and build tensors at import time, and the score-formatting logic in the `/predict` and `/similarities` routes is currently inline with the tensor math rather than separated out.
+
+Recommended approach:
+- **Refactor first**: extract the score→JSON formatting (rounding, threshold filtering in `/predict`, min-max normalization in `/similarities`) into small pure functions so they're unit-testable without a loaded model.
+- **Smoke/integration test** for the model itself: start the service, `POST` a fixed known text, assert the response shape and that every score is in `[0, 1]`. Mark this slow/optional in CI — it needs to download model weights and doesn't need to run on every commit.
+
+## 8. Frontend
+
+Requires installing Jest or Vitest + React Testing Library first.
+
+**Pure logic (no rendering required):**
+- `lib/utils.ts` — `cn()` class merging/deduplication.
+- `components/editModal.tsx` — `parseSdgFromString` (extracting number/name from strings like `"SDG 3: Health"`), `getSdgNumber`/`getSdgName` (string vs. object `sdg` shape), duplicate-SDG rejection in `addNewSDG`.
+- `components/results.tsx` — `isNoSdgs` (null, empty array, empty object, all-zero-score object, mixed number/`SDGValue` shapes), `getScore` (number vs. `SDGValue` vs. undefined).
+- `components/mainScreen.tsx` — the inline repo-URL validation regex (`/^\/[^/]+\/[^/]+/`): valid GitHub/GitLab path, bare domain with no path, malformed URL string.
+- `services/api.ts` — `classifyByModel` switch: each model type routes to the correct client method; an unknown type falls back to Aurora.
+
+**Component tests:**
+- `mainScreen.tsx` — every form-validation message branch ("Please fill in...", "valid repository URL").
+- `results.tsx` — tab switching (`handleTabChange`) and its error path, `handleDownload`'s JSON/blob generation.
+- `editModal.tsx` — add/remove SDG flow end to end.
+
+## 9. Cross-cutting / necessary but not "unit tests"
+
+- **Contract tests** between `frontend/services/api.ts` and the backend routes — would have caught the missing `classify_st_description` endpoint automatically instead of at runtime.
+- **SSRF consideration**: `fetch_repo_text`/`get_provider` take a user-supplied URL and the *server* makes outbound requests to it. `_sanitise_url` currently only validates URL *shape*, not destination — it will happily route to `http://localhost/...` or an internal `169.254.169.254`/RFC1918 address if a domain-map or engine-detection match were ever added for one. Worth a test (and likely a fix) confirming internal/private hosts are rejected before any request is issued.
+- **Missing dependency**: `python-dotenv` is imported in `summariser.py` but is not listed in [`backend/requirements.txt`](../backend/requirements.txt) — this currently breaks a clean `pip install -r requirements.txt` followed by running anything that imports the summariser.
+- **Rate-limit and timeout behavior** against real forges (GitHub/GitLab/Codeberg/Bitbucket) isn't practical to unit test — track this as a documented manual/staging check instead.
+- **End-to-end smoke test**: submit a real, known-good repository URL through the full stack and confirm a plausible SDG comes back. This is what [`backend/tests/test_dpga_real_positives.py`](../backend/tests/test_dpga_real_positives.py) already does by hand. It belongs in a manual/nightly tier, not the automated unit suite, since it depends on three live external services (the forge API, the GE-Lab microservice, and the embedding model).
+
+## Suggested priority order for contributors
+
+1. Install `pytest` for `backend/` and `models/`; install Jest/Vitest + RTL for `frontend/`.
+2. `backend/services/repo_fetcher.py` — pure logic, highest test-to-effort ratio.
+3. `backend/services/summariser.py` and `backend/aurora_api.py` — both are mockable HTTP-boundary modules with well-defined fallback paths.
+4. `backend/app.py` route tests, once the `classify_st_description` gap is resolved.
+5. Frontend pure-logic tests, then component tests.
+6. `models/` — after extracting the pure formatting logic out of the model-loading routes.

--- a/frontend/components/results.tsx
+++ b/frontend/components/results.tsx
@@ -73,7 +73,7 @@ const Results = ({ results, setResults, setError }: ResultsProps) => {
 
     try {
       const response = await classifyByModel(
-        newTab as "aurora" | "st-description" | "st-url",
+        newTab as "aurora" | "st-url",
         requestData,
       );
 
@@ -240,31 +240,6 @@ const Results = ({ results, setResults, setError }: ResultsProps) => {
                         <IoIosInformationCircleOutline className="ml-2 text-purple-600 cursor-help" />
                         <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-48 px-3 py-2 text-xs text-white bg-gray-800 rounded-lg shadow-lg z-10 whitespace-normal">
                           This is a third party API from EU Alliance Research
-                          <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 border-4 border-transparent border-t-gray-800"></span>
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-
-                  <button
-                    onClick={() => handleTabChange("st-description")}
-                    disabled={isLoadingTab}
-                    className={`w-full text-left px-4 py-3 rounded-lg transition-all duration-200 relative ${
-                      activeTab === "st-description"
-                        ? "bg-purple-50 text-purple-700 font-semibold"
-                        : "text-gray-700 hover:bg-gray-50"
-                    } disabled:opacity-50 disabled:cursor-not-allowed`}
-                  >
-                    {activeTab === "st-description" && (
-                      <div className="absolute left-0 top-1/2 transform -translate-y-1/2 w-1 h-8 bg-purple-600 rounded-r-full"></div>
-                    )}
-                    <span className="ml-2">
-                      Sentence Transformer Description
-                      <span className="relative group inline-block">
-                        <IoIosInformationCircleOutline className="ml-2 text-purple-600 cursor-help" />
-                        <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-48 px-3 py-2 text-xs text-white bg-gray-800 rounded-lg shadow-lg z-10 whitespace-normal">
-                          This is a sentence transformer modal from Huggingface
-                          that analyzes the project description.
                           <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-1 border-4 border-transparent border-t-gray-800"></span>
                         </span>
                       </span>

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -25,16 +25,6 @@ export const sdgApi = {
     return response.data;
   },
 
-  classifySTDescription: async (
-    data: SDGClassificationRequest,
-  ): Promise<SDGClassificationResponse> => {
-    const response = await apiClient.post<SDGClassificationResponse>(
-      "api/classify_st_description",
-      data,
-    );
-    return response.data;
-  },
-
   classifySTUrl: async (
     data: SDGClassificationRequest,
   ): Promise<SDGClassificationResponse> => {
@@ -49,14 +39,12 @@ export const sdgApi = {
 // Helper to get classification by model
 
 export const classifyByModel = async (
-  modelType: "aurora" | "st-description" | "st-url",
+  modelType: "aurora" | "st-url",
   data: SDGClassificationRequest,
 ): Promise<SDGClassificationResponse> => {
   switch (modelType) {
     case "aurora":
       return sdgApi.classifyAurora(data);
-    case "st-description":
-      return sdgApi.classifySTDescription(data);
     case "st-url":
       return sdgApi.classifySTUrl(data);
     default:


### PR DESCRIPTION
## Summary

1.  Reorganized stray test scripts (4fc91e7) — moved backend/test.py and backend/services/test.py (two scripts with no naming consistency) into a proper backend/tests/ folder, renamed to test_dpga_real_positives.py and test_gitlab_provider.py based on what they actually test, with import paths fixed for the new location.

2. Wrote the testing strategy doc (docs/TESTING.md) — a full inventory of what testing this project needs across the backend, the ML microservice, and the frontend: current state (no framework existed anywhere), specific test cases per module, cross-cutting concerns (SSRF exposure in the repo-fetching code, a missing dependency), and a suggested priority order.

3. Fixed a real bug found while writing that doc (8a93c4b) — the frontend was calling api/classify_st_description, a backend route that never existed. Removed the dead client method, the switch case, and the corresponding UI tab in results.tsx rather than adding an unused route.

4. Built the first automated backend test suite (be44b7c) — added pytest to backend/requirements.txt, a conftest.py (path setup + excludes the manual scripts from collection), and test_repo_fetcher.py: 72 tests covering URL sanitization, all four supported hosts (GitHub/GitLab/Codeberg/Bitbucket), the full HTTP error-to-exception mapping, and the provider factory — fully mocked, no live network calls, runs in under a second.